### PR TITLE
Fix children render with containing `null` (or similar) item

### DIFF
--- a/src/Menu.jsx
+++ b/src/Menu.jsx
@@ -207,6 +207,7 @@ const Menu = React.createClass({
   },
 
   renderMenuItem(c, i, subIndex) {
+    if (!c) return null;
     const key = getKeyFromChildrenIndex(c, this.props.eventKey, i);
     const state = this.state;
     const extraProps = {


### PR DESCRIPTION
https://github.com/ant-design/ant-design/issues/1746