### PR TITLE
fix: controlled inline mode should not be interactive

### DIFF
--- a/src/Menu.jsx
+++ b/src/Menu.jsx
@@ -148,7 +148,9 @@ const Menu = React.createClass({
     }
     if (changed) {
       // hack, synchronous call from onTitleMouseEnter
-      this.state.openKeys = openKeys;
+      if (props.mode !== 'inline') {
+        this.state.openKeys = openKeys;
+      }
       if (!('openKeys' in this.props)) {
         // hack: batch does not update state
         this.setState({ openKeys });


### PR DESCRIPTION
close: https://github.com/ant-design/ant-design/issues/2701

直接修改就破坏受控模式了，`vertical` `horizontal` 的受控模式似乎没有人用到，但是 `inline` 的受控模式还是需要的。

hack 上加 hack 的感觉 。。。。