### PR TITLE
[fix] cannot read preperty of null

### DIFF
--- a/src/MenuMixin.js
+++ b/src/MenuMixin.js
@@ -20,7 +20,7 @@ function getActiveKey(props, originalActiveKey) {
   if (activeKey) {
     let found;
     loopMenuItem(children, (c, i) => {
-      if (!c.props.disabled && activeKey === getKeyFromChildrenIndex(c, eventKey, i)) {
+      if (c && !c.props.disabled && activeKey === getKeyFromChildrenIndex(c, eventKey, i)) {
         found = true;
       }
     });


### PR DESCRIPTION
```
function renderAdminMenu(){
  if(isAdmin){
     return <SubMenu>.......</SubMenu>;
  }
  return;
}
<Menu>
   <SubMenu key="a">......</SubMenu>
    {this.renderAdminMenu()}
<Menu.Item>......</Menu.Item>
</Menu>

修复当使用上面的代码时会因为renderAdminMenu 返回的是null,
报Uncaught TypeError: Cannot read property 'props' of null