### PR TITLE
fix(MenuMixin): allow `null`, `undefined` or `Boolean` as child

### DIFF
--- a/src/MenuMixin.js
+++ b/src/MenuMixin.js
@@ -20,7 +20,7 @@ function getActiveKey(props, originalActiveKey) {
   if (activeKey) {
     let found;
     loopMenuItem(children, (c, i) => {
-      if (!c.props.disabled && activeKey === getKeyFromChildrenIndex(c, eventKey, i)) {
+      if (c && !c.props.disabled && activeKey === getKeyFromChildrenIndex(c, eventKey, i)) {
         found = true;
       }
     });


### PR DESCRIPTION
某些动态计算 Menu children 的情形，可能导致 Menu 中的某个 child 变为 null、undefined 或 true/false，这里应该做个优雅兼容。

```jsx
<Menu>
  {shouldShowItem && <Item />}
</Menu>
```