### PR TITLE
Fix aria warning in react@15.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "expect.js": "~0.3.1",
     "font-awesome": "~4.2.0",
     "pre-commit": "1.x",
-    "rc-tools": "5.x",
+    "rc-tools": "5.8.11",
     "react": "15.x",
     "react-addons-test-utils": "15.x",
     "react-dom": "15.x"

--- a/src/SubMenu.jsx
+++ b/src/SubMenu.jsx
@@ -419,7 +419,7 @@ const SubMenu = React.createClass({
           className={`${prefixCls}-title`}
           {...titleMouseEvents}
           {...titleClickEvents}
-          aria-open={isOpen}
+          aria-expanded={isOpen}
           aria-owns={this._menuId}
           aria-haspopup="true"
         >


### PR DESCRIPTION
aria-open => aria-expanded

`aria-open` is not a valid aria prop: https://www.w3.org/TR/wai-aria-1.1/#global_states

ant-design/ant-design#3882