### PR TITLE
fix: when subMenu's children is null

### DIFF
--- a/src/SubPopupMenu.js
+++ b/src/SubPopupMenu.js
@@ -52,6 +52,9 @@ const SubPopupMenu = React.createClass({
   },
 
   renderMenuItem(c, i, subIndex) {
+    if (!c) {
+      return null;
+    }
     const props = this.props;
     const extraProps = {
       openKeys: props.openKeys,


### PR DESCRIPTION
错误信息：Uncaught TypeError: Cannot read property 'key' of null
示例：http://codepen.io/skyriver9/pen/vybwZM?editors=0010
          导航 - 子菜单2