### PR TITLE
Update rc-util version to 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
   - yiminghe@gmail.com
 
 node_js:
-- 4.0.0
+- 6.0.0
 
 before_install:
 - |

--- a/package.json
+++ b/package.json
@@ -56,9 +56,9 @@
     "jest": "^17.0.3",
     "pre-commit": "1.x",
     "rc-tools": "5.x",
-    "react": "15.x",
-    "react-addons-test-utils": "15.x",
-    "react-dom": "15.x"
+    "react": "15.4.x",
+    "react-addons-test-utils": "15.4.x",
+    "react-dom": "15.4.x"
   },
   "dependencies": {
     "babel-runtime": "6.x",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "classnames": "2.x",
     "dom-scroll-into-view": "1.x",
     "rc-animate": "2.x",
-    "rc-util": "3.x"
+    "rc-util": "^4.0.2"
   },
   "pre-commit": [
     "lint"


### PR DESCRIPTION
As far as I can tell there are no breaking changes that affect `rc-menu`

This change can solve some issues where `rc-util` 3.x is required by another module. It solves this: (as long as you don't have any other rc components that use rc-util 3.x) https://github.com/react-component/trigger/issues/34