### PR TITLE
Add selectable option into Menu doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ ReactDOM.render(<Menu>
             <td>whether allow multiple select</td>
         </tr>
         <tr>
+            <td>selectable</td>
+            <td>Boolean</td>
+            <th>true</th>
+            <td>allow selecting menu items</td>
+        </tr>
+        <tr>
             <td>selectedKeys</td>
             <td>String[]</td>
             <th>[]</th>


### PR DESCRIPTION
I needed the selectable prop and had to read the source code to see there was an option here. 

https://github.com/react-component/menu/issues/33