### PR TITLE
Keep state when submenu destroy

### DIFF
--- a/src/Menu.jsx
+++ b/src/Menu.jsx
@@ -76,21 +76,6 @@ const Menu = createReactClass({
     this.setState(props);
   },
 
-  onDestroy(key) {
-    const state = this.state;
-    const props = this.props;
-    const selectedKeys = state.selectedKeys;
-    const openKeys = state.openKeys;
-    let index = selectedKeys.indexOf(key);
-    if (!('selectedKeys' in props) && index !== -1) {
-      selectedKeys.splice(index, 1);
-    }
-    index = openKeys.indexOf(key);
-    if (!('openKeys' in props) && index !== -1) {
-      openKeys.splice(index, 1);
-    }
-  },
-
   onSelect(selectInfo) {
     const props = this.props;
     if (props.selectable) {

--- a/src/MenuMixin.js
+++ b/src/MenuMixin.js
@@ -209,7 +209,6 @@ const MenuMixin = {
       forceSubMenuRender: props.forceSubMenuRender,
       onOpenChange: this.onOpenChange,
       onDeselect: this.onDeselect,
-      onDestroy: this.onDestroy,
       onSelect: this.onSelect,
       ...extraProps,
     };

--- a/tests/MenuItem.spec.js
+++ b/tests/MenuItem.spec.js
@@ -33,18 +33,4 @@ describe('MenuItem', () => {
       expect(handleSelect).not.toBeCalled();
     });
   });
-
-  describe('unmount', () => {
-    it('removes self from selectedKeys', () => {
-      const wrapper = mount(
-        <Menu>
-          <MenuItem key="1">1</MenuItem>
-        </Menu>
-      );
-      wrapper.find('MenuItem').simulate('click');
-      expect(wrapper.state('selectedKeys')).toEqual(['1']);
-      wrapper.setProps({ children: null });
-      expect(wrapper.state('selectedKeys')).toEqual([]);
-    });
-  });
 });

--- a/tests/SubMenu.spec.js
+++ b/tests/SubMenu.spec.js
@@ -96,14 +96,6 @@ describe('SubMenu', () => {
       );
     };
 
-    it('removes self key from openKeys', () => {
-      const wrapper = mount(<App show />);
-      wrapper.find('.rc-menu-submenu-title').first().simulate('mouseEnter');
-      expect(wrapper.find('Menu').instance().state.openKeys).toEqual(['s1']);
-      wrapper.setProps({ show: false });
-      expect(wrapper.find('Menu').instance().state.openKeys).toEqual([]);
-    });
-
     it('clears parent timers', () => {
       const wrapper = mount(<App show />);
       const parentMenu = wrapper.find('Menu').first();


### PR DESCRIPTION
close ant-design/ant-design#8567

It is not reasonable to clear openKeys and selectedKeys when submenu destroy