### PR TITLE
Support change the aria role of menu or menuitem.

### DIFF
--- a/src/Menu.jsx
+++ b/src/Menu.jsx
@@ -28,6 +28,7 @@ const Menu = createReactClass({
     selectable: PropTypes.bool,
     multiple: PropTypes.bool,
     children: PropTypes.any,
+    role: PropTypes.string,
   },
 
   mixins: [MenuMixin],

--- a/src/MenuItem.jsx
+++ b/src/MenuItem.jsx
@@ -125,12 +125,12 @@ const MenuItem = createReactClass({
       [this.getDisabledClassName()]: props.disabled,
     });
     const attrs = {
-      ...props.attribute,
-      title: props.title,
-      className,
       role: 'menuitem',
       'aria-selected': selected,
       'aria-disabled': props.disabled,
+      ...props.attribute,
+      title: props.title,
+      className,
     };
     let mouseEvent = {};
     if (!props.disabled) {

--- a/src/MenuMixin.js
+++ b/src/MenuMixin.js
@@ -65,6 +65,7 @@ const MenuMixin = {
     defaultOpenKeys: PropTypes.arrayOf(PropTypes.string),
     openKeys: PropTypes.arrayOf(PropTypes.string),
     children: PropTypes.any,
+    role: PropTypes.string,
   },
 
   getDefaultProps() {
@@ -225,11 +226,12 @@ const MenuMixin = {
       props.className,
       `${props.prefixCls}-${props.mode}`,
     );
+
     const domProps = {
       className,
-      role: 'menu',
-      'aria-activedescendant': '',
+      role: props.role || 'menu',
     };
+
     if (props.id) {
       domProps.id = props.id;
     }

--- a/tests/Menu.spec.js
+++ b/tests/Menu.spec.js
@@ -39,6 +39,27 @@ describe('Menu', () => {
     });
   });
 
+  describe('render role listbox', () => {
+    function createMenu() {
+      return (
+        <Menu
+          className="myMenu"
+          openAnimation="fade"
+          role="listbox"
+        >
+          <MenuItem key="1" attribute={{ role: 'option' }}>1</MenuItem>
+          <MenuItem key="2" attribute={{ role: 'option' }}>2</MenuItem>
+          <MenuItem key="3" attribute={{ role: 'option' }}>3</MenuItem>
+        </Menu>
+      );
+    }
+
+    it(`renders menu correctly`, () => {
+      const wrapper = render(createMenu());
+      expect(renderToJson(wrapper)).toMatchSnapshot();
+    });
+  });
+
 
   it('set activeKey', () => {
     const wrapper = mount(

--- a/tests/__snapshots__/Menu.spec.js.snap
+++ b/tests/__snapshots__/Menu.spec.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Menu render renders horizontal menu correctly 1`] = `
 <ul
-  aria-activedescendant=""
   class="rc-menu myMenu rc-menu-root rc-menu-vertical"
   role="menu"
   tabindex="0"
@@ -95,7 +94,6 @@ exports[`Menu render renders horizontal menu correctly 1`] = `
 
 exports[`Menu render renders inline menu correctly 1`] = `
 <ul
-  aria-activedescendant=""
   class="rc-menu myMenu rc-menu-root rc-menu-vertical"
   role="menu"
   tabindex="0"
@@ -188,7 +186,6 @@ exports[`Menu render renders inline menu correctly 1`] = `
 
 exports[`Menu render renders vertical menu correctly 1`] = `
 <ul
-  aria-activedescendant=""
   class="rc-menu myMenu rc-menu-root rc-menu-vertical"
   role="menu"
   tabindex="0"
@@ -275,6 +272,36 @@ exports[`Menu render renders vertical menu correctly 1`] = `
         class="rc-menu-submenu-arrow"
       />
     </div>
+  </li>
+</ul>
+`;
+
+exports[`Menu render role listbox renders menu correctly 1`] = `
+<ul
+  class="rc-menu myMenu rc-menu-root rc-menu-vertical"
+  role="listbox"
+  tabindex="0"
+>
+  <li
+    aria-selected="false"
+    class="rc-menu-item"
+    role="option"
+  >
+    1
+  </li>
+  <li
+    aria-selected="false"
+    class="rc-menu-item"
+    role="option"
+  >
+    2
+  </li>
+  <li
+    aria-selected="false"
+    class="rc-menu-item"
+    role="option"
+  >
+    3
   </li>
 </ul>
 `;


### PR DESCRIPTION
# When menu is used with select support search mode

- the role of menu should be `listbox`
- the role of menuitem should be `option`

so that, the screen reader like `nvda` can read the item in option.

# Remove the aria-activedescendant

This attribute has no meaning in menu.

# Ref
- https://www.w3.org/TR/wai-aria/roles#combobox
- https://www.w3.org/WAI/GL/wiki/Using_aria-activedescendant_to_allow_changes_in_focus_within_widgets_to_be_communicated_to_Assistive_Technology

