### PR TITLE
perf: refactor to avoid unnecessary re-render with mini-store

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "classnames": "2.x",
     "create-react-class": "^15.5.2",
     "dom-scroll-into-view": "1.x",
+    "mini-store": "^1.0.2",
     "prop-types": "^15.5.6",
     "rc-animate": "2.x",
     "rc-trigger": "^2.3.0",

--- a/src/Menu.jsx
+++ b/src/Menu.jsx
@@ -190,7 +190,7 @@ const Menu = createReactClass({
     return lastOpen[0];
   },
 
-  renderMenuItem(c, i, subIndex) {
+  renderMenuItem(c, i, subIndex, subMenuKey) {
     if (!c) {
       return null;
     }
@@ -199,6 +199,7 @@ const Menu = createReactClass({
       openKeys: state.openKeys,
       selectedKeys: state.selectedKeys,
       triggerSubMenuAction: this.props.triggerSubMenuAction,
+      subMenuKey,
     };
     return this.renderCommonMenuItem(c, i, subIndex, extraProps);
   },

--- a/src/MenuItem.jsx
+++ b/src/MenuItem.jsx
@@ -164,5 +164,5 @@ MenuItem.isMenuItem = 1;
 
 export default connect(({ activeKey, selectedKeys }, { eventKey }) => ({
   active: activeKey[getMenuIdFromItemEventKey(eventKey)] === eventKey,
-  isSelected: selectedKeys.findIndex((k) => k === eventKey) !== -1,
+  isSelected: selectedKeys.indexOf(eventKey) !== -1,
 }))(MenuItem);

--- a/src/MenuItem.jsx
+++ b/src/MenuItem.jsx
@@ -4,7 +4,7 @@ import createReactClass from 'create-react-class';
 import KeyCode from 'rc-util/lib/KeyCode';
 import classNames from 'classnames';
 import { connect } from 'mini-store';
-import { noop, getMenuIdFromItemEventKey } from './util';
+import { noop } from './util';
 
 /* eslint react/no-is-mounted:0 */
 
@@ -162,7 +162,7 @@ const MenuItem = createReactClass({
 
 MenuItem.isMenuItem = 1;
 
-export default connect(({ activeKey, selectedKeys }, { eventKey }) => ({
-  active: activeKey[getMenuIdFromItemEventKey(eventKey)] === eventKey,
+export default connect(({ activeKey, selectedKeys }, { eventKey, subMenuKey }) => ({
+  active: activeKey[subMenuKey] === eventKey,
   isSelected: selectedKeys.indexOf(eventKey) !== -1,
 }))(MenuItem);

--- a/src/MenuItem.jsx
+++ b/src/MenuItem.jsx
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import KeyCode from 'rc-util/lib/KeyCode';
 import classNames from 'classnames';
-import { noop } from './util';
+import { connect } from 'mini-store';
+import { noop, getMenuIdFromItemEventKey } from './util';
 
 /* eslint react/no-is-mounted:0 */
 
@@ -43,6 +44,13 @@ const MenuItem = createReactClass({
     }
   },
 
+  componentDidMount() {
+    // invoke customized ref to expose component to mixin
+    if (this.props.manualRef) {
+      this.props.manualRef(this);
+    }
+  },
+
   onKeyDown(e) {
     const keyCode = e.keyCode;
     if (keyCode === KeyCode.ENTER) {
@@ -76,8 +84,7 @@ const MenuItem = createReactClass({
   },
 
   onClick(e) {
-    const { eventKey, multiple, onClick, onSelect, onDeselect } = this.props;
-    const selected = this.isSelected();
+    const { eventKey, multiple, onClick, onSelect, onDeselect, isSelected } = this.props;
     const info = {
       key: eventKey,
       keyPath: [eventKey],
@@ -86,12 +93,12 @@ const MenuItem = createReactClass({
     };
     onClick(info);
     if (multiple) {
-      if (selected) {
+      if (isSelected) {
         onDeselect(info);
       } else {
         onSelect(info);
       }
-    } else if (!selected) {
+    } else if (!isSelected) {
       onSelect(info);
     }
   },
@@ -112,16 +119,11 @@ const MenuItem = createReactClass({
     return `${this.getPrefixCls()}-disabled`;
   },
 
-  isSelected() {
-    return this.props.selectedKeys.indexOf(this.props.eventKey) !== -1;
-  },
-
   render() {
     const props = this.props;
-    const selected = this.isSelected();
     const className = classNames(this.getPrefixCls(), props.className, {
       [this.getActiveClassName()]: !props.disabled && props.active,
-      [this.getSelectedClassName()]: selected,
+      [this.getSelectedClassName()]: props.isSelected,
       [this.getDisabledClassName()]: props.disabled,
     });
     const attrs = {
@@ -129,7 +131,7 @@ const MenuItem = createReactClass({
       title: props.title,
       className,
       role: 'menuitem',
-      'aria-selected': selected,
+      'aria-selected': props.isSelected,
       'aria-disabled': props.disabled,
     };
     let mouseEvent = {};
@@ -160,4 +162,7 @@ const MenuItem = createReactClass({
 
 MenuItem.isMenuItem = 1;
 
-export default MenuItem;
+export default connect(({ activeKey, selectedKeys }, { eventKey }) => ({
+  active: activeKey[getMenuIdFromItemEventKey(eventKey)] === eventKey,
+  isSelected: selectedKeys.findIndex((k) => k === eventKey) !== -1,
+}))(MenuItem);

--- a/src/MenuItemGroup.jsx
+++ b/src/MenuItemGroup.jsx
@@ -19,7 +19,7 @@ const MenuItemGroup = createReactClass({
 
   renderInnerMenuItem(item, subIndex) {
     const { renderMenuItem, index } = this.props;
-    return renderMenuItem(item, index, subIndex);
+    return renderMenuItem(item, index, subIndex, this.props.subMenuKey);
   },
 
   render() {

--- a/src/MenuMixin.js
+++ b/src/MenuMixin.js
@@ -92,16 +92,11 @@ const MenuMixin = {
 
   componentWillReceiveProps(nextProps) {
     let activeKey;
-    if ('activeKey' in nextProps) {
-      activeKey = getActiveKey(nextProps, nextProps.activeKey);
+    const originalActiveKey = this.getStore().getState().activeKey[this.getEventKey()];
+    activeKey = getActiveKey(nextProps, originalActiveKey);
+    // fix: this.setState(), parent.render(),
+    if (activeKey !== originalActiveKey) {
       updateActiveKey(this.getStore(), this.getEventKey(), activeKey);
-    } else {
-      const originalActiveKey = this.getStore().getState().activeKey[this.getEventKey()];
-      activeKey = getActiveKey(nextProps, originalActiveKey);
-      // fix: this.setState(), parent.render(),
-      if (activeKey !== originalActiveKey) {
-        updateActiveKey(this.getStore(), this.getEventKey(), activeKey);
-      }
     }
   },
 
@@ -256,7 +251,10 @@ const MenuMixin = {
         visible={props.visible}
         {...domProps}
       >
-        {React.Children.map(props.children, this.renderMenuItem)}
+        {React.Children.map(
+          props.children,
+          (c, i, subIndex) => this.renderMenuItem(c, i, subIndex, props.eventKey || '0-menu-'),
+        )}
       </DOMWrap>
       /*eslint-enable */
     );

--- a/src/SubMenu.jsx
+++ b/src/SubMenu.jsx
@@ -453,7 +453,6 @@ const SubMenu = createReactClass({
 SubMenu.isSubMenu = 1;
 
 export default connect(({ openKeys, activeKey }, { eventKey }) => ({
-  // k is of type integer, and eventKey is of type string
-  isOpen: openKeys.findIndex((k) => k === eventKey) > -1,
+  isOpen: openKeys.indexOf(eventKey) > -1,
   active: activeKey[getMenuIdFromItemEventKey(eventKey)] === eventKey,
 }))(SubMenu);

--- a/src/SubMenu.jsx
+++ b/src/SubMenu.jsx
@@ -5,9 +5,15 @@ import createReactClass from 'create-react-class';
 import Trigger from 'rc-trigger';
 import KeyCode from 'rc-util/lib/KeyCode';
 import classNames from 'classnames';
+import { connect } from 'mini-store';
 import SubPopupMenu from './SubPopupMenu';
 import placements from './placements';
-import { noop, loopMenuItemRecusively } from './util';
+import {
+  noop,
+  loopMenuItemRecusively,
+  getMenuIdFromItemEventKey,
+  getMenuIdFromSubMenuEventKey,
+} from './util';
 
 let guid = 0;
 
@@ -16,6 +22,17 @@ const popupPlacementMap = {
   vertical: 'rightTop',
   'vertical-left': 'rightTop',
   'vertical-right': 'leftTop',
+};
+
+const updateDefaultActiveFirst = (store, eventKey, defaultActiveFirst) => {
+  const menuId = getMenuIdFromSubMenuEventKey(eventKey);
+  const state = store.getState();
+  store.setState({
+    defaultActiveFirst: {
+      ...state.defaultActiveFirst,
+      [menuId]: defaultActiveFirst,
+    },
+  });
 };
 
 const SubMenu = createReactClass({
@@ -43,6 +60,7 @@ const SubMenu = createReactClass({
     onTitleMouseEnter: PropTypes.func,
     onTitleMouseLeave: PropTypes.func,
     onTitleClick: PropTypes.func,
+    isOpen: PropTypes.bool,
   },
 
   isRootMenu: false,
@@ -60,18 +78,32 @@ const SubMenu = createReactClass({
 
   getInitialState() {
     this.isSubMenu = 1;
-    return {
-      defaultActiveFirst: false,
-    };
+    const props = this.props;
+    const store = props.store;
+    const eventKey = props.eventKey;
+    const defaultActiveFirst = store.getState().defaultActiveFirst;
+    let value = false;
+
+    if (defaultActiveFirst) {
+      value = defaultActiveFirst[eventKey];
+    }
+
+    updateDefaultActiveFirst(store, eventKey, value);
+
+    return {};
   },
 
   componentDidMount() {
     this.componentDidUpdate();
+    // invoke customized ref to expose component to mixin
+    if (this.props.manualRef) {
+      this.props.manualRef(this);
+    }
   },
 
   componentDidUpdate() {
     const { mode, parentMenu } = this.props;
-    if (mode !== 'horizontal' || !parentMenu.isRootMenu || !this.isOpen()) {
+    if (mode !== 'horizontal' || !parentMenu.isRootMenu || !this.props.isOpen) {
       return;
     }
     this.minWidthTimeout = setTimeout(() => {
@@ -106,13 +138,14 @@ const SubMenu = createReactClass({
   onKeyDown(e) {
     const keyCode = e.keyCode;
     const menu = this.menuInstance;
-    const isOpen = this.isOpen();
+    const {
+      isOpen,
+      store,
+    } = this.props;
 
     if (keyCode === KeyCode.ENTER) {
       this.onTitleClick(e);
-      this.setState({
-        defaultActiveFirst: true,
-      });
+      updateDefaultActiveFirst(store, this.props.eventKey, true);
       return true;
     }
 
@@ -121,9 +154,8 @@ const SubMenu = createReactClass({
         menu.onKeyDown(e);
       } else {
         this.triggerOpenChange(true);
-        this.setState({
-          defaultActiveFirst: true,
-        });
+        // need to update current menu's defaultActiveFirst value
+        updateDefaultActiveFirst(store, this.props.eventKey, true);
       }
       return true;
     }
@@ -155,10 +187,8 @@ const SubMenu = createReactClass({
   },
 
   onMouseEnter(e) {
-    const { eventKey: key, onMouseEnter } = this.props;
-    this.setState({
-      defaultActiveFirst: false,
-    });
+    const { eventKey: key, onMouseEnter, store } = this.props;
+    updateDefaultActiveFirst(store, this.props.eventKey, true);
     onMouseEnter({
       key,
       domEvent: e,
@@ -212,10 +242,8 @@ const SubMenu = createReactClass({
     if (props.triggerSubMenuAction === 'hover') {
       return;
     }
-    this.triggerOpenChange(!this.isOpen(), 'click');
-    this.setState({
-      defaultActiveFirst: false,
-    });
+    this.triggerOpenChange(!props.isOpen, 'click');
+    updateDefaultActiveFirst(props.store, this.props.eventKey, true);
   },
 
   onSubMenuClick(info) {
@@ -251,6 +279,7 @@ const SubMenu = createReactClass({
   },
 
   saveMenuInstance(c) {
+    // children menu instance
     this.menuInstance = c;
   },
 
@@ -295,7 +324,7 @@ const SubMenu = createReactClass({
     const props = this.props;
     const baseProps = {
       mode: props.mode === 'horizontal' ? 'vertical' : props.mode,
-      visible: this.isOpen(),
+      visible: this.props.isOpen,
       level: props.level + 1,
       inlineIndent: props.inlineIndent,
       focusable: false,
@@ -313,11 +342,12 @@ const SubMenu = createReactClass({
       subMenuCloseDelay: props.subMenuCloseDelay,
       forceSubMenuRender: props.forceSubMenuRender,
       triggerSubMenuAction: props.triggerSubMenuAction,
-      defaultActiveFirst: this.state.defaultActiveFirst,
+      defaultActiveFirst: props.store.getState()
+        .defaultActiveFirst[getMenuIdFromSubMenuEventKey(props.eventKey)],
       multiple: props.multiple,
       prefixCls: props.rootPrefixCls,
       id: this._menuId,
-      ref: this.saveMenuInstance,
+      manualRef: this.saveMenuInstance,
     };
     return <SubPopupMenu {...baseProps}>{children}</SubPopupMenu>;
   },
@@ -328,7 +358,7 @@ const SubMenu = createReactClass({
 
   render() {
     const props = this.props;
-    const isOpen = this.isOpen();
+    const isOpen = props.isOpen;
     const prefixCls = this.getPrefixCls();
     const isInlineMode = props.mode === 'inline';
     const className = classNames(prefixCls, `${prefixCls}-${props.mode}`, {
@@ -392,6 +422,7 @@ const SubMenu = createReactClass({
       props.parentMenu.props.getPopupContainer : triggerNode => triggerNode.parentNode;
     const popupPlacement = popupPlacementMap[props.mode];
     const popupClassName = props.mode === 'inline' ? '' : props.popupClassName;
+
     return (
       <li {...mouseEvents} className={className} style={props.style}>
         {isInlineMode && title}
@@ -421,4 +452,8 @@ const SubMenu = createReactClass({
 
 SubMenu.isSubMenu = 1;
 
-export default SubMenu;
+export default connect(({ openKeys, activeKey }, { eventKey }) => ({
+  // k is of type integer, and eventKey is of type string
+  isOpen: openKeys.findIndex((k) => k === eventKey) > -1,
+  active: activeKey[getMenuIdFromItemEventKey(eventKey)] === eventKey,
+}))(SubMenu);

--- a/src/SubMenu.jsx
+++ b/src/SubMenu.jsx
@@ -11,7 +11,6 @@ import placements from './placements';
 import {
   noop,
   loopMenuItemRecusively,
-  getMenuIdFromItemEventKey,
   getMenuIdFromSubMenuEventKey,
 } from './util';
 
@@ -452,7 +451,7 @@ const SubMenu = createReactClass({
 
 SubMenu.isSubMenu = 1;
 
-export default connect(({ openKeys, activeKey }, { eventKey }) => ({
+export default connect(({ openKeys, activeKey }, { eventKey, subMenuKey }) => ({
   isOpen: openKeys.indexOf(eventKey) > -1,
-  active: activeKey[getMenuIdFromItemEventKey(eventKey)] === eventKey,
+  active: activeKey[subMenuKey] === eventKey,
 }))(SubMenu);

--- a/src/SubPopupMenu.js
+++ b/src/SubPopupMenu.js
@@ -66,7 +66,7 @@ const SubPopupMenu = createReactClass({
     return this.props.openTransitionName;
   },
 
-  renderMenuItem(c, i, subIndex) {
+  renderMenuItem(c, i, subIndex, subMenuKey) {
     if (!c) {
       return null;
     }
@@ -75,6 +75,7 @@ const SubPopupMenu = createReactClass({
       openKeys: props.openKeys,
       selectedKeys: props.selectedKeys,
       triggerSubMenuAction: props.triggerSubMenuAction,
+      subMenuKey,
     };
     return this.renderCommonMenuItem(c, i, subIndex, extraProps);
   },

--- a/src/SubPopupMenu.js
+++ b/src/SubPopupMenu.js
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import Animate from 'rc-animate';
-import MenuMixin from './MenuMixin';
+import { connect } from 'mini-store';
+import { default as MenuMixin, getActiveKey } from './MenuMixin';
 
 const SubPopupMenu = createReactClass({
   displayName: 'SubPopupMenu',
@@ -21,6 +22,25 @@ const SubPopupMenu = createReactClass({
   },
 
   mixins: [MenuMixin],
+
+  getInitialState() {
+    const props = this.props;
+    props.store.setState({
+      activeKey: {
+        ...props.store.getState().activeKey,
+        [props.eventKey]: getActiveKey(props, props.activeKey),
+      },
+    });
+
+    return {};
+  },
+
+  componentDidMount() {
+    // invoke customized ref to expose component to mixin
+    if (this.props.manualRef) {
+      this.props.manualRef(this);
+    }
+  },
 
   onDeselect(selectInfo) {
     this.props.onDeselect(selectInfo);
@@ -96,4 +116,4 @@ const SubPopupMenu = createReactClass({
   },
 });
 
-export default SubPopupMenu;
+export default connect()(SubPopupMenu);

--- a/src/util.js
+++ b/src/util.js
@@ -8,23 +8,6 @@ export function getKeyFromChildrenIndex(child, menuEventKey, index) {
   return child.key || `${prefix}item_${index}`;
 }
 
-/*
- find which menu an item with particular event that it belongs to.
- e.g.:
-   eventkey of '1' or '2' belongs to root menu ('0-menu-')
-   eventkey of '2-1' or '2-2' belongs to sub menu with key id '2-menu-'
-   eventkey of '2-2-1' or '2-2-2' belongs to sub menu with key id '2-2-menu-'
-*/
-export function getMenuIdFromItemEventKey(eventkey) {
-  const index = eventkey.lastIndexOf('-');
-  if (index === -1) {
-    return '0-menu-';
-  }
-
-  const ret = eventkey.slice(0, index);
-  return `${ret}-menu-`;
-}
-
 export function getMenuIdFromSubMenuEventKey(eventKey) {
   return `${eventKey}-menu-`;
 }

--- a/src/util.js
+++ b/src/util.js
@@ -8,6 +8,27 @@ export function getKeyFromChildrenIndex(child, menuEventKey, index) {
   return child.key || `${prefix}item_${index}`;
 }
 
+/*
+ find which menu an item with particular event that it belongs to.
+ e.g.:
+   eventkey of '1' or '2' belongs to root menu ('0-menu-')
+   eventkey of '2-1' or '2-2' belongs to sub menu with key id '2-menu-'
+   eventkey of '2-2-1' or '2-2-2' belongs to sub menu with key id '2-2-menu-'
+*/
+export function getMenuIdFromItemEventKey(eventkey) {
+  const index = eventkey.lastIndexOf('-');
+  if (index === -1) {
+    return '0-menu-';
+  }
+
+  const ret = eventkey.slice(0, index);
+  return `${ret}-menu-`;
+}
+
+export function getMenuIdFromSubMenuEventKey(eventKey) {
+  return `${eventKey}-menu-`;
+}
+
 export function loopMenuItem(children, cb) {
   let index = -1;
   React.Children.forEach(children, (c) => {

--- a/tests/SubMenu.spec.js
+++ b/tests/SubMenu.spec.js
@@ -16,10 +16,10 @@ describe('SubMenu', () => {
     return (
       <Menu {...props}>
         <SubMenu key="s1" title="submenu1">
-          <MenuItem key="1">1</MenuItem>
+          <MenuItem key="s1-1">1</MenuItem>
         </SubMenu>
         <SubMenu key="s2" title="submenu2">
-          <MenuItem key="2">2</MenuItem>
+          <MenuItem key="s2-2">2</MenuItem>
         </SubMenu>
       </Menu>
     );
@@ -34,20 +34,20 @@ describe('SubMenu', () => {
       </Menu>
     );
     wrapper.find('.rc-menu-submenu-title').first().simulate('mouseEnter');
-    expect(wrapper.state('openKeys')).toEqual([]);
+    expect(wrapper.instance().store.getState().openKeys).toEqual([]);
   });
 
-  describe('openSubMenuOnMouseEnter and closeSubMenuOnMouseLeave are ture', () => {
+  describe('openSubMenuOnMouseEnter and closeSubMenuOnMouseLeave are true', () => {
     it('toggles when mouse enter and leave', () => {
       const wrapper = mount(createMenu());
 
       wrapper.find('.rc-menu-submenu-title').first().simulate('mouseEnter');
       jest.runAllTimers();
-      expect(wrapper.state('openKeys')).toEqual(['s1']);
+      expect(wrapper.instance().store.getState().openKeys).toEqual(['s1']);
 
       wrapper.find('.rc-menu-submenu-title').first().simulate('mouseLeave');
       jest.runAllTimers();
-      expect(wrapper.state('openKeys')).toEqual([]);
+      expect(wrapper.instance().store.getState().openKeys).toEqual([]);
     });
   });
 
@@ -62,10 +62,10 @@ describe('SubMenu', () => {
 
     it('toggles when mouse click', () => {
       wrapper.find('.rc-menu-submenu-title').first().simulate('click');
-      expect(wrapper.state('openKeys')).toEqual(['s1']);
+      expect(wrapper.instance().store.getState().openKeys).toEqual(['s1']);
 
       wrapper.find('.rc-menu-submenu-title').first().simulate('click');
-      expect(wrapper.state('openKeys')).toEqual([]);
+      expect(wrapper.instance().store.getState().openKeys).toEqual([]);
     });
   });
 
@@ -112,14 +112,13 @@ describe('SubMenu', () => {
 
     describe('left & right key', () => {
       it('toggles menu', () => {
-        const wrapper = mount(createMenu());
+        const wrapper = mount(createMenu({ defaultActiveFirst: true }));
         const title = wrapper.find('.rc-menu-submenu-title').first();
 
         title.simulate('mouseEnter').simulate('keyDown', { keyCode: KeyCode.LEFT });
-        expect(wrapper.state('openKeys')).toEqual([]);
+        expect(wrapper.instance().store.getState().openKeys).toEqual([]);
         title.simulate('keyDown', { keyCode: KeyCode.RIGHT });
-        expect(wrapper.state('openKeys')).toEqual(['s1']);
-
+        expect(wrapper.instance().store.getState().openKeys).toEqual(['s1']);
         expect(wrapper.find('MenuItem').first().props().active).toBe(true);
       });
     });
@@ -148,7 +147,7 @@ describe('SubMenu', () => {
     wrapper.update();
 
     wrapper.find('MenuItem').first().simulate('click');
-    expect(handleSelect.mock.calls[0][0].key).toBe('1');
+    expect(handleSelect.mock.calls[0][0].key).toBe('s1-1');
   });
 
   it('fires deselect event for multiple menu', () => {
@@ -165,6 +164,6 @@ describe('SubMenu', () => {
     wrapper.find('MenuItem').first().simulate('click');
     wrapper.find('MenuItem').first().simulate('click');
 
-    expect(handleDeselect.mock.calls[0][0].key).toBe('1');
+    expect(handleDeselect.mock.calls[0][0].key).toBe('s1-1');
   });
 });


### PR DESCRIPTION
Using mini store to subscribe local change to improve performance.

Before:
![before](https://user-images.githubusercontent.com/1731837/37409451-5b50f92e-27d9-11e8-9b78-c5531114e0ce.gif)

After:
![after](https://user-images.githubusercontent.com/1731837/37409487-6cf77db0-27d9-11e8-909b-8b98454c72e7.gif)

Notes: 
1. Every menu and subMenu have to keep their own entrance in mini store for both activeKey and defaultActiveFirst configuration.
2. All unit tests passed and verified carefully that all behaviors are identical to previous version.

TODO items:
1. We wanted to get rid of mixin once for all, but it was too big change to go with this one. Not confident enough to do that refactor yet...
2. Mini Store does not support setState callbacks, might need some help. But it should be a very minor thing.