### PR TITLE
chore: fix aria-* attirbutes

### DIFF
--- a/src/MenuItem.jsx
+++ b/src/MenuItem.jsx
@@ -11,6 +11,7 @@ import { noop, menuAllProps } from './util';
 
 export class MenuItem extends React.Component {
   static propTypes = {
+    attribute: PropTypes.object,
     rootPrefixCls: PropTypes.string,
     eventKey: PropTypes.string,
     active: PropTypes.bool,
@@ -145,14 +146,27 @@ export class MenuItem extends React.Component {
       [this.getSelectedClassName()]: props.isSelected,
       [this.getDisabledClassName()]: props.disabled,
     });
-    const attrs = {
+    let attrs = {
       ...props.attribute,
       title: props.title,
       className,
+      // set to menuitem by default
       role: 'menuitem',
-      'aria-selected': props.isSelected,
       'aria-disabled': props.disabled,
     };
+
+    if (props.role === 'option') {
+      // overwrite to option
+      attrs = {
+        ...attrs,
+        role: 'option',
+        'aria-selected': props.isSelected,
+      };
+    } else if (attrs.role === null) {
+      // sometimes we want to specify role inside <li/> element
+      // <li><a role='menuitem'>Link</a></li> would be a good example
+      delete attrs.role;
+    }
     let mouseEvent = {};
     if (!props.disabled) {
       mouseEvent = {
@@ -181,11 +195,11 @@ export class MenuItem extends React.Component {
   }
 }
 
+MenuItem.isMenuItem = true;
+
 const connected = connect(({ activeKey, selectedKeys }, { eventKey, subMenuKey }) => ({
   active: activeKey[subMenuKey] === eventKey,
   isSelected: selectedKeys.indexOf(eventKey) !== -1,
 }))(MenuItem);
-
-connected.isMenuItem = true;
 
 export default connected;

--- a/src/MenuItem.jsx
+++ b/src/MenuItem.jsx
@@ -162,7 +162,7 @@ export class MenuItem extends React.Component {
         role: 'option',
         'aria-selected': props.isSelected,
       };
-    } else if (attrs.role === null) {
+    } else if (props.role === null) {
       // sometimes we want to specify role inside <li/> element
       // <li><a role='menuitem'>Link</a></li> would be a good example
       delete attrs.role;

--- a/src/SubMenu.jsx
+++ b/src/SubMenu.jsx
@@ -399,7 +399,7 @@ export class SubMenu extends React.Component {
         component=""
         transitionAppear={transitionAppear}
       >
-        <SubPopupMenu {...baseProps}>{children}</SubPopupMenu>
+        <SubPopupMenu {...baseProps} id={this._menuId}>{children}</SubPopupMenu>
       </Animate>
     );
   }
@@ -448,6 +448,17 @@ export class SubMenu extends React.Component {
     if (isInlineMode) {
       style.paddingLeft = props.inlineIndent * props.level;
     }
+
+    let ariaOwns = {};
+    // only set aria-owns when menu is open
+    // otherwise it would be an invalid aria-owns value
+    // since corresponding node cannot be found
+    if (this.props.isOpen) {
+      ariaOwns = {
+        'aria-owns': this._menuId,
+      };
+    }
+
     const title = (
       <div
         ref={this.saveSubMenuTitle}
@@ -456,7 +467,7 @@ export class SubMenu extends React.Component {
         {...titleMouseEvents}
         {...titleClickEvents}
         aria-expanded={isOpen}
-        aria-owns={this._menuId}
+        {...ariaOwns}
         aria-haspopup="true"
         title={typeof props.title === 'string' ? props.title : undefined}
       >
@@ -479,7 +490,7 @@ export class SubMenu extends React.Component {
     } = props;
     menuAllProps.forEach(key => delete props[key]);
     return (
-      <li {...props} {...mouseEvents} className={className}>
+      <li {...props} {...mouseEvents} className={className} role="menuitem">
         {isInlineMode && title}
         {isInlineMode && children}
         {!isInlineMode && (

--- a/src/SubPopupMenu.js
+++ b/src/SubPopupMenu.js
@@ -316,8 +316,8 @@ export class SubPopupMenu extends React.Component {
     );
     const domProps = {
       className,
-      role: 'menu',
-      'aria-activedescendant': '',
+      // role could be 'select' and by default set to menu
+      role: props.role || 'menu',
     };
     if (props.id) {
       domProps.id = props.id;

--- a/tests/Menu.spec.js
+++ b/tests/Menu.spec.js
@@ -39,6 +39,27 @@ describe('Menu', () => {
     });
   });
 
+  describe('render role listbox', () => {
+    function createMenu() {
+      return (
+        <Menu
+          className="myMenu"
+          openAnimation="fade"
+          role="listbox"
+        >
+          <MenuItem key="1" role="option">1</MenuItem>
+          <MenuItem key="2" role="option">2</MenuItem>
+          <MenuItem key="3" role="option">3</MenuItem>
+        </Menu>
+      );
+    }
+
+    it(`renders menu correctly`, () => {
+      const wrapper = render(createMenu());
+      expect(renderToJson(wrapper)).toMatchSnapshot();
+    });
+  });
+
   it('set activeKey', () => {
     const wrapper = mount(
       <Menu activeKey="1">

--- a/tests/MenuItem.spec.js
+++ b/tests/MenuItem.spec.js
@@ -112,4 +112,18 @@ describe('MenuItem', () => {
       expect(onClick).toHaveBeenCalledTimes(3);
     });
   });
+
+  describe('overwrite default role', () => {
+    it('should set empty role', () => {
+      const wrapper = shallow(<NakedMenuItem role={null}>test</NakedMenuItem>);
+
+      expect(wrapper.render()).toMatchSnapshot();
+    });
+
+    it('should set specific role', () => {
+      const wrapper = shallow(<NakedMenuItem role="option">test</NakedMenuItem>);
+
+      expect(wrapper.render()).toMatchSnapshot();
+    });
+  });
 });

--- a/tests/__snapshots__/Menu.spec.js.snap
+++ b/tests/__snapshots__/Menu.spec.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Menu render renders horizontal menu correctly 1`] = `
 <ul
-  aria-activedescendant=""
   class="rc-menu myMenu rc-menu-root rc-menu-horizontal"
   role="menu"
   tabindex="0"
@@ -20,7 +19,6 @@ exports[`Menu render renders horizontal menu correctly 1`] = `
       class="rc-menu-item-group-list"
     >
       <li
-        aria-selected="false"
         class="rc-menu-item"
         role="menuitem"
       >
@@ -30,7 +28,6 @@ exports[`Menu render renders horizontal menu correctly 1`] = `
         class=" rc-menu-item-divider"
       />
       <li
-        aria-selected="false"
         class="rc-menu-item"
         role="menuitem"
       >
@@ -39,7 +36,6 @@ exports[`Menu render renders horizontal menu correctly 1`] = `
     </ul>
   </li>
   <li
-    aria-selected="false"
     class="rc-menu-item"
     role="menuitem"
   >
@@ -58,7 +54,6 @@ exports[`Menu render renders horizontal menu correctly 1`] = `
       class="rc-menu-item-group-list"
     >
       <li
-        aria-selected="false"
         class="rc-menu-item"
         role="menuitem"
       >
@@ -66,7 +61,6 @@ exports[`Menu render renders horizontal menu correctly 1`] = `
       </li>
       <li
         aria-disabled="true"
-        aria-selected="false"
         class="rc-menu-item rc-menu-item-disabled"
         role="menuitem"
       >
@@ -76,11 +70,11 @@ exports[`Menu render renders horizontal menu correctly 1`] = `
   </li>
   <li
     class="rc-menu-submenu rc-menu-submenu-horizontal"
+    role="menuitem"
   >
     <div
       aria-expanded="false"
       aria-haspopup="true"
-      aria-owns="item_3$Menu"
       class="rc-menu-submenu-title"
       title="submenu"
     >
@@ -95,7 +89,6 @@ exports[`Menu render renders horizontal menu correctly 1`] = `
 
 exports[`Menu render renders inline menu correctly 1`] = `
 <ul
-  aria-activedescendant=""
   class="rc-menu myMenu rc-menu-root rc-menu-inline"
   role="menu"
   tabindex="0"
@@ -113,7 +106,6 @@ exports[`Menu render renders inline menu correctly 1`] = `
       class="rc-menu-item-group-list"
     >
       <li
-        aria-selected="false"
         class="rc-menu-item"
         role="menuitem"
         style="padding-left:24px"
@@ -124,7 +116,6 @@ exports[`Menu render renders inline menu correctly 1`] = `
         class=" rc-menu-item-divider"
       />
       <li
-        aria-selected="false"
         class="rc-menu-item"
         role="menuitem"
         style="padding-left:24px"
@@ -134,7 +125,6 @@ exports[`Menu render renders inline menu correctly 1`] = `
     </ul>
   </li>
   <li
-    aria-selected="false"
     class="rc-menu-item"
     role="menuitem"
     style="padding-left:24px"
@@ -154,7 +144,6 @@ exports[`Menu render renders inline menu correctly 1`] = `
       class="rc-menu-item-group-list"
     >
       <li
-        aria-selected="false"
         class="rc-menu-item"
         role="menuitem"
         style="padding-left:24px"
@@ -163,7 +152,6 @@ exports[`Menu render renders inline menu correctly 1`] = `
       </li>
       <li
         aria-disabled="true"
-        aria-selected="false"
         class="rc-menu-item rc-menu-item-disabled"
         role="menuitem"
         style="padding-left:24px"
@@ -174,11 +162,11 @@ exports[`Menu render renders inline menu correctly 1`] = `
   </li>
   <li
     class="rc-menu-submenu rc-menu-submenu-inline"
+    role="menuitem"
   >
     <div
       aria-expanded="false"
       aria-haspopup="true"
-      aria-owns="item_3$Menu"
       class="rc-menu-submenu-title"
       style="padding-left:24px"
       title="submenu"
@@ -195,7 +183,6 @@ exports[`Menu render renders inline menu correctly 1`] = `
 
 exports[`Menu render renders vertical menu correctly 1`] = `
 <ul
-  aria-activedescendant=""
   class="rc-menu myMenu rc-menu-root rc-menu-vertical"
   role="menu"
   tabindex="0"
@@ -213,7 +200,6 @@ exports[`Menu render renders vertical menu correctly 1`] = `
       class="rc-menu-item-group-list"
     >
       <li
-        aria-selected="false"
         class="rc-menu-item"
         role="menuitem"
       >
@@ -223,7 +209,6 @@ exports[`Menu render renders vertical menu correctly 1`] = `
         class=" rc-menu-item-divider"
       />
       <li
-        aria-selected="false"
         class="rc-menu-item"
         role="menuitem"
       >
@@ -232,7 +217,6 @@ exports[`Menu render renders vertical menu correctly 1`] = `
     </ul>
   </li>
   <li
-    aria-selected="false"
     class="rc-menu-item"
     role="menuitem"
   >
@@ -251,7 +235,6 @@ exports[`Menu render renders vertical menu correctly 1`] = `
       class="rc-menu-item-group-list"
     >
       <li
-        aria-selected="false"
         class="rc-menu-item"
         role="menuitem"
       >
@@ -259,7 +242,6 @@ exports[`Menu render renders vertical menu correctly 1`] = `
       </li>
       <li
         aria-disabled="true"
-        aria-selected="false"
         class="rc-menu-item rc-menu-item-disabled"
         role="menuitem"
       >
@@ -269,11 +251,11 @@ exports[`Menu render renders vertical menu correctly 1`] = `
   </li>
   <li
     class="rc-menu-submenu rc-menu-submenu-vertical"
+    role="menuitem"
   >
     <div
       aria-expanded="false"
       aria-haspopup="true"
-      aria-owns="item_3$Menu"
       class="rc-menu-submenu-title"
       title="submenu"
     >

--- a/tests/__snapshots__/Menu.spec.js.snap
+++ b/tests/__snapshots__/Menu.spec.js.snap
@@ -267,3 +267,33 @@ exports[`Menu render renders vertical menu correctly 1`] = `
   </li>
 </ul>
 `;
+
+exports[`Menu render role listbox renders menu correctly 1`] = `
+<ul
+  class="rc-menu myMenu rc-menu-root rc-menu-vertical"
+  role="listbox"
+  tabindex="0"
+>
+  <li
+    aria-selected="false"
+    class="rc-menu-item"
+    role="option"
+  >
+    1
+  </li>
+  <li
+    aria-selected="false"
+    class="rc-menu-item"
+    role="option"
+  >
+    2
+  </li>
+  <li
+    aria-selected="false"
+    class="rc-menu-item"
+    role="option"
+  >
+    3
+  </li>
+</ul>
+`;

--- a/tests/__snapshots__/MenuItem.spec.js.snap
+++ b/tests/__snapshots__/MenuItem.spec.js.snap
@@ -2,13 +2,11 @@
 
 exports[`MenuItem rest props can render all props to sub component 1`] = `
 <ul
-  aria-activedescendant=""
   class="rc-menu  rc-menu-root rc-menu-inline"
   role="menu"
   tabindex="0"
 >
   <li
-    aria-selected="false"
     class="rc-menu-item className rc-menu-item-active"
     data-whatever="whatever"
     role="menuitem"
@@ -20,12 +18,12 @@ exports[`MenuItem rest props can render all props to sub component 1`] = `
   <li
     class="rc-menu-submenu rc-menu-submenu-inline className"
     data-whatever="whatever"
+    role="menuitem"
     style="font-size: 20px;"
   >
     <div
       aria-expanded="false"
       aria-haspopup="true"
-      aria-owns="item_1$Menu"
       class="rc-menu-submenu-title"
       style="padding-left: 24px;"
       title="title"
@@ -52,7 +50,6 @@ exports[`MenuItem rest props can render all props to sub component 1`] = `
       class="rc-menu-item-group-list"
     >
       <li
-        aria-selected="false"
         class="rc-menu-item className"
         data-whatever="whatever"
         role="menuitem"

--- a/tests/__snapshots__/MenuItem.spec.js.snap
+++ b/tests/__snapshots__/MenuItem.spec.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`MenuItem overwrite default role should set empty role 1`] = `
+<li
+  class="undefined-item"
+>
+  test
+</li>
+`;
+
+exports[`MenuItem overwrite default role should set specific role 1`] = `
+<li
+  class="undefined-item"
+  role="option"
+>
+  test
+</li>
+`;
+
 exports[`MenuItem rest props can render all props to sub component 1`] = `
 <ul
   class="rc-menu  rc-menu-root rc-menu-inline"


### PR DESCRIPTION
https://github.com/ant-design/ant-design/issues/10095

The idea is to fix the area-* attributes issue and avoid any breaking changes

before:
<img width="871" alt="before" src="https://user-images.githubusercontent.com/1731837/39362276-6da9e04e-4a58-11e8-940a-9daf333f62b3.png">

after:
<img width="746" alt="after" src="https://user-images.githubusercontent.com/1731837/39362292-7ea7d2b6-4a58-11e8-9956-689f00d29143.png">
