### PR TITLE
[WIP]fix: passing onclick through

### DIFF
--- a/examples/antd.js
+++ b/examples/antd.js
@@ -11,6 +11,10 @@ function handleSelect(info) {
   console.log(`selected ${info.key}`);
 }
 
+function handleItemClick(e) {
+  console.log('item clicked');
+}
+
 const animation = {
   enter(node, done) {
     let height;
@@ -52,24 +56,24 @@ const animation = {
 const reactContainer = document.getElementById('__react-content');
 
 const nestSubMenu = (<SubMenu title={<span>offset sub menu 2</span>} key="4" popupOffset={[10, 15]}>
-  <MenuItem key="4-1">inner inner</MenuItem>
+  <MenuItem key="4-1" whatever="inner inner" onClick={handleItemClick}>inner inner</MenuItem>
   <Divider/>
   <SubMenu
     key="4-2"
     title={<span>sub menu 3</span>}
   >
     <SubMenu title="sub 4-2-0" key="4-2-0">
-      <MenuItem key="4-2-0-1">inner inner</MenuItem>
-      <MenuItem key="4-2-0-2">inner inner2</MenuItem>
+      <MenuItem key="4-2-0-1" whatever="inner inner1" onClick={handleItemClick}>inner inner1</MenuItem>
+      <MenuItem key="4-2-0-2" whatever="inner inner2" onClick={handleItemClick}>inner inner2</MenuItem>
     </SubMenu>
-    <MenuItem key="4-2-1">inn</MenuItem>
+    <MenuItem key="4-2-1" whatever="inner inner3" onClick={handleItemClick}>inner inner3</MenuItem>
     <SubMenu title={<span>sub menu 4</span>} key="4-2-2">
-      <MenuItem key="4-2-2-1">inner inner</MenuItem>
-      <MenuItem key="4-2-2-2">inner inner2</MenuItem>
+      <MenuItem key="4-2-2-1" whatever="inner inner4" onClick={handleItemClick}>inner inner4</MenuItem>
+      <MenuItem key="4-2-2-2" whatever="inner inner5" onClick={handleItemClick}>inner inner5</MenuItem>
     </SubMenu>
     <SubMenu title="sub 4-2-3" key="4-2-3">
-      <MenuItem key="4-2-3-1">inner inner</MenuItem>
-      <MenuItem key="4-2-3-2">inner inner2</MenuItem>
+      <MenuItem key="4-2-3-1" whatever="inner inner6" onClick={handleItemClick}>inner inner6</MenuItem>
+      <MenuItem key="4-2-3-2" whatever="inner inner7" onClick={handleItemClick}>inner inner7</MenuItem>
     </SubMenu>
   </SubMenu>
 </SubMenu>);
@@ -77,16 +81,16 @@ const nestSubMenu = (<SubMenu title={<span>offset sub menu 2</span>} key="4" pop
 function onOpenChange(value) {
   console.log('onOpenChange', value);
 }
-const commonMenu = (<Menu onSelect={handleSelect} onOpenChange={onOpenChange}>
+const commonMenu = (<Menu onClick={handleSelect} onOpenChange={onOpenChange}>
   <SubMenu title={<span>sub menu</span>} key="1">
-    <MenuItem key="1-1">0-1</MenuItem>
-    <MenuItem key="1-2">0-2</MenuItem>
+    <MenuItem key="1-1" onClick={handleItemClick}>0-1</MenuItem>
+    <MenuItem key="1-2" onClick={handleItemClick}>0-2</MenuItem>
   </SubMenu>
   {nestSubMenu}
-  <MenuItem key="2">1</MenuItem>
-  <MenuItem key="3">outer</MenuItem>
+  <MenuItem key="2" onClick={handleItemClick}>1</MenuItem>
+  <MenuItem key="3" onClick={handleItemClick}>outer</MenuItem>
   <MenuItem disabled>disabled</MenuItem>
-  <MenuItem key="5">outer3</MenuItem>
+  <MenuItem key="5" onClick={handleItemClick}>outer3</MenuItem>
 </Menu>);
 
 function render(container) {

--- a/src/SubMenu.jsx
+++ b/src/SubMenu.jsx
@@ -12,7 +12,6 @@ import {
   noop,
   loopMenuItemRecursively,
   getMenuIdFromSubMenuEventKey,
-  menuAllProps,
 } from './util';
 
 let guid = 0;
@@ -490,9 +489,8 @@ export class SubMenu extends React.Component {
       forceSubMenuRender,
       subMenuCloseDelay,
     } = props;
-    menuAllProps.forEach(key => delete props[key]);
     return (
-      <li {...props} {...mouseEvents} className={className} role="menuitem">
+      <li {...mouseEvents} className={className} role="menuitem">
         {isInlineMode && title}
         {isInlineMode && children}
         {!isInlineMode && (

--- a/src/SubPopupMenu.js
+++ b/src/SubPopupMenu.js
@@ -4,7 +4,7 @@ import { connect } from 'mini-store';
 import KeyCode from 'rc-util/lib/KeyCode';
 import createChainedFunction from 'rc-util/lib/createChainedFunction';
 import classNames from 'classnames';
-import { getKeyFromChildrenIndex, loopMenuItem, noop, menuAllProps } from './util';
+import { getKeyFromChildrenIndex, loopMenuItem, noop } from './util';
 import DOMWrap from './DOMWrap';
 
 function allDisabled(arr) {
@@ -327,12 +327,11 @@ export class SubPopupMenu extends React.Component {
       domProps.onKeyDown = this.onKeyDown;
     }
     const { prefixCls, eventKey, visible } = props;
-    menuAllProps.forEach(key => delete props[key]);
     return (
       // ESLint is not smart enough to know that the type of `children` was checked.
       /* eslint-disable */
       <DOMWrap
-        {...props}
+        style={props.style}
         tag="ul"
         hiddenClassName={`${prefixCls}-hidden`}
         visible={visible}

--- a/tests/MenuItem.spec.js
+++ b/tests/MenuItem.spec.js
@@ -106,10 +106,6 @@ describe('MenuItem', () => {
       expect(wrapper.render()).toMatchSnapshot();
       wrapper.find('MenuItem').at(0).simulate('click');
       expect(onClick).toHaveBeenCalledTimes(1);
-      wrapper.find('SubMenu').at(0).simulate('click');
-      expect(onClick).toHaveBeenCalledTimes(2);
-      wrapper.find('MenuItemGroup').at(0).simulate('click');
-      expect(onClick).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/tests/__snapshots__/MenuItem.spec.js.snap
+++ b/tests/__snapshots__/MenuItem.spec.js.snap
@@ -34,9 +34,7 @@ exports[`MenuItem rest props can render all props to sub component 1`] = `
   </li>
   <li
     class="rc-menu-submenu rc-menu-submenu-inline className"
-    data-whatever="whatever"
     role="menuitem"
-    style="font-size: 20px;"
   >
     <div
       aria-expanded="false"


### PR DESCRIPTION
https://github.com/react-component/menu/pull/140 出现的[问题](https://github.com/ant-design/ant-design/issues/10375)是[inherit props](https://github.com/react-component/menu/pull/135)导致的；而https://github.com/react-component/menu/pull/135 想解决的问题是https://github.com/ant-design/ant-design/issues/9004

因为我们用的是cloneElement的方法，所以[inherit props](https://github.com/react-component/menu/pull/135) ~~不得不把onClick事件一层层传下去，但是也正因为在中间层subMenu/subPopupMenu传递了onClick，所以才会触发不必要的冒泡，所以这里给出的解决方案是：
既然我们只是想把onClick传下去，那么在中间层重命名一下，不要叫onClick，这样就不会响应错误的冒泡事件了。~~ 

其实在MenuItem这一层做{...props}不已经解决了[Menu.Item should have the onClick param](https://github.com/ant-design/ant-design/issues/9004)？只要删去中间层(subMenu/subPopupMenu)不必要的{...Props}，除非有什么情况是我们需要响应的？

