### PR TITLE
Fix Warning where wrapper <li> props had a popupAlign prop stolen from Trigger

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -84,6 +84,7 @@ export const menuAllProps = [
   'onTitleMouseEnter',
   'onTitleMouseLeave',
   'onTitleClick',
+  'popupAlign',
   'popupOffset',
   'isOpen',
   'renderMenuItem',


### PR DESCRIPTION
For some reason, even though `popupAlign` is never passed into the `props` and only into the `<Trigger>` component, we still get a Warning saying that `popupAlign` isn't a recognized DOM element as a part of the `<li>`.

This will fix this. Passes all tests.