### PR TITLE
fix: preventive check in setChildrenSize

### DIFF
--- a/src/DOMWrap.jsx
+++ b/src/DOMWrap.jsx
@@ -109,6 +109,11 @@ class DOMWrap extends React.Component {
 
       () => { // callback
         const ul = container.childNodes[0];
+
+        if (!ul) {
+          return;
+        }
+
         const scrollWidth = getScrollWidth(ul);
 
         this.props.children.forEach((c, i) => this.childrenSizes[i] = getWidth(ul.children[i]));


### PR DESCRIPTION
A quick fix for ant.design site console error. A thorough fix will be included in https://github.com/react-component/menu/pull/172

<img width="443" alt="screen shot 2018-07-16 at 10 00 07 am" src="https://user-images.githubusercontent.com/1731837/42740841-1e5a8fbe-88df-11e8-8620-056923a0e59a.png">
