### PR TITLE
Why not use 'process' instead of window.

### DIFF
--- a/src/DOMWrap.jsx
+++ b/src/DOMWrap.jsx
@@ -6,7 +6,7 @@ import SubMenu from './SubMenu';
 import { getWidth } from './util';
 
 // Fix ssr
-if (typeof window !== 'undefined') {
+if (typeof process === 'undefined') {
   require('mutationobserver-shim');
 }
 


### PR DESCRIPTION
Some SSR frameworks like NextJS break when using ```typeof window !== 'undefined'```. It looks as though a polyfill of ```window``` exists on the server side, so changing it to check for ```process``` is better in my opinion.

**Update:** It seems to be related to AWS Amplify polyfilling the ```window``` object.