### PR TITLE
Fix: made default mode 'vertical' to be center

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ ReactDOM.render(<Menu>
         <tr>
           <td>mode</td>
           <td>String</td>
-          <td>vertical</td>
+          <th>vertical</th>
           <td>one of ["horizontal","inline","vertical-left","vertical-right"]</td>
         </tr>
         <tr>


### PR DESCRIPTION
I saw that the word vertical does not use <th> tag. I just made it consistent with other default value in the table.