### PR TITLE
:arrow_up: Bump mini-store to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "babel-runtime": "6.x",
     "classnames": "2.x",
     "dom-scroll-into-view": "1.x",
-    "mini-store": "^1.1.0",
+    "mini-store": "^2.0.0",
     "mutationobserver-shim": "^0.3.2",
     "prop-types": "^15.5.6",
     "rc-animate": "2.x",


### PR DESCRIPTION
`rc-table` 更新 mini-store 2.0.0，同步更新 mini-store 到相同版本，否则会出现 menu 和 table 引用两个不同版本的 mini-store。