### PR TITLE
[chore] fix logical error in SubMenu.jsx

### DIFF
--- a/src/SubMenu.jsx
+++ b/src/SubMenu.jsx
@@ -388,7 +388,7 @@ export class SubMenu extends React.Component {
     // don't show transition on first rendering (no animation for opened menu)
     // show appear transition if it's not visible (not sure why)
     // show appear transition if it's not inline mode
-    const transitionAppear = haveRendered || !baseProps.visible || !baseProps.mode === 'inline';
+    const transitionAppear = haveRendered || !baseProps.visible || baseProps.mode !== 'inline';
 
     baseProps.className = ` ${baseProps.prefixCls}-sub`;
     const animProps = {};


### PR DESCRIPTION
not (`!`) binds more tightly than equality comparisons, so the third clause in this expression is incorrect:

https://github.com/react-component/menu/blob/a540719c46a274641d618bfa5d121360d3ed9f54/src/SubMenu.jsx#L388-L391

`!baseProps.mode === 'inline'` is equivalent to `(!baseProps.mode) === 'inline'` which will always equal false, as neither `true` nor `false` are exactly equal to `'inline'`.

I found this problem on the [alert list for this project on LGTM.com](https://lgtm.com/projects/g/react-component/menu/alerts), while going through results. The only other remaining alerts are 2 alerts that are in example code.

*(Full disclosure: I'm part of the team behind LGTM.com)*