### PR TITLE
🚨 fix inconsistent component state updates in example code

### DIFF
--- a/examples/selectedKeys.js
+++ b/examples/selectedKeys.js
@@ -34,9 +34,9 @@ class Test extends React.Component {
   onCheck = (e) => {
     const value = e.target.value;
     if (e.target.checked) {
-      this.setState({
-        selectedKeys: this.state.selectedKeys.concat(value),
-      });
+      this.setState(state => ({
+        selectedKeys: state.selectedKeys.concat(value),
+      }));
     } else {
       const selectedKeys = this.state.selectedKeys.concat();
       const index = selectedKeys.indexOf(value);
@@ -52,9 +52,9 @@ class Test extends React.Component {
   onOpenCheck = (e) => {
     const value = e.target.value;
     if (e.target.checked) {
-      this.setState({
-        openKeys: this.state.openKeys.concat(value),
-      });
+      this.setState(state => ({
+        openKeys: state.openKeys.concat(value),
+      }));
     } else {
       const openKeys = this.state.openKeys.concat();
       const index = openKeys.indexOf(value);


### PR DESCRIPTION
I know that this is just in example code, but given that these are the only two alerts remaining for this project on LGTM, I thought it's probably worth the PR :)

React component state updates using `setState` may asynchronously update `this.props` and `this.state`, thus it is not safe to use either of the two when calculating the new state passed to `setState`, and instead the callback-based variant should be used instead. ([details here](https://lgtm.com/rules/1819283066/)).

These were [found on LGTM.com](https://lgtm.com/projects/g/react-component/menu/alerts), and other than the alert fixed in #230, there are no remaining alerts.

*(Full disclosure: I'm part of the team behind LGTM.com)*
