### PR TITLE
 Set the same precision for chrome and firefox

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -110,11 +110,20 @@ export const menuAllProps = [
   'expandIcon',
 ];
 
-export const getWidth = (elem) => (
-  elem &&
-  typeof elem.getBoundingClientRect === 'function' &&
-  elem.getBoundingClientRect().width
-) || 0;
+/*
+ * ref: https://github.com/ant-design/ant-design/issues/14007
+ * ref: https://bugs.chromium.org/p/chromium/issues/detail?id=360889
+ * getBoundingClientRect return the full precision value, which is 
+ * not the same behavior as on chrome. Set the precision to 6 to 
+ * unify their behavior
+ */ 
+export const getWidth = (elem) => {
+  let width = elem && typeof elem.getBoundingClientRect === 'function' && elem.getBoundingClientRect().width;
+  if (width) {
+    width = width.toFixed(6);
+  }
+  return width || 0;
+};
 
 export const setStyle = (elem, styleProperty, value) => {
   if (elem && typeof elem.style === 'object') {

--- a/src/util.js
+++ b/src/util.js
@@ -110,15 +110,16 @@ export const menuAllProps = [
   'expandIcon',
 ];
 
-/*
- * ref: https://github.com/ant-design/ant-design/issues/14007
- * ref: https://bugs.chromium.org/p/chromium/issues/detail?id=360889
- * getBoundingClientRect return the full precision value, which is 
- * not the same behavior as on chrome. Set the precision to 6 to 
- * unify their behavior
- */ 
+
+// ref: https://github.com/ant-design/ant-design/issues/14007
+// ref: https://bugs.chromium.org/p/chromium/issues/detail?id=360889
+// getBoundingClientRect return the full precision value, which is
+// not the same behavior as on chrome. Set the precision to 6 to
+// unify their behavior
 export const getWidth = (elem) => {
-  let width = elem && typeof elem.getBoundingClientRect === 'function' && elem.getBoundingClientRect().width;
+  let width = elem &&
+    typeof elem.getBoundingClientRect === 'function' &&
+    elem.getBoundingClientRect().width;
   if (width) {
     width = width.toFixed(6);
   }


### PR DESCRIPTION
FIx https://github.com/ant-design/ant-design/issues/14007