### PR TITLE
Fixes #256

### DIFF
--- a/examples/menuItemGroup.js
+++ b/examples/menuItemGroup.js
@@ -13,7 +13,13 @@ ReactDOM.render(<div>
       <MenuItem key="21">2</MenuItem>
       <MenuItem key="22">3</MenuItem>
     </MenuItemGroup>
-    <MenuItemGroup title="group 2" key="3">
+    <MenuItemGroup title="group 2" key="3"
+      titleNode={(
+        <span>
+          <span style={{ fontWeight: 600, fontStyle: 'italic' }}>group</span> 2
+        </span>
+      )}
+    >
       <MenuItem key="31">4</MenuItem>
       <MenuItem key="32">5</MenuItem>
     </MenuItemGroup>

--- a/src/MenuItemGroup.jsx
+++ b/src/MenuItemGroup.jsx
@@ -9,6 +9,7 @@ class MenuItemGroup extends React.Component {
     className: PropTypes.string,
     subMenuKey: PropTypes.string,
     rootPrefixCls: PropTypes.string,
+    titleNode: PropTypes.node,
   };
 
   static defaultProps = {
@@ -25,7 +26,7 @@ class MenuItemGroup extends React.Component {
     const { className = '', rootPrefixCls } = props;
     const titleClassName = `${rootPrefixCls}-item-group-title`;
     const listClassName = `${rootPrefixCls}-item-group-list`;
-    const { title, children } = props;
+    const { title, titleNode, children } = props;
     menuAllProps.forEach(key => delete props[key]);
 
     // Set onClick to null, to ignore propagated onClick event
@@ -37,7 +38,7 @@ class MenuItemGroup extends React.Component {
           className={titleClassName}
           title={typeof title === 'string' ? title : undefined}
         >
-          {title}
+          {titleNode || title}
         </div>
         <ul className={listClassName}>
           {React.Children.map(children, this.renderInnerMenuItem)}

--- a/tests/Menu.spec.js
+++ b/tests/Menu.spec.js
@@ -24,11 +24,22 @@ describe('Menu', () => {
             <MenuItem key="2">2</MenuItem>
           </MenuItemGroup>
           <MenuItem key="3">3</MenuItem>
-          <MenuItemGroup title="g2">
+          <MenuItemGroup title="g2"
+            titleNode={(
+              <span>
+                <span style={{ fontWeight: 600, fontStyle: 'italic' }}>g2</span>
+              </span>
+            )}
+          >
             <MenuItem key="4">4</MenuItem>
             <MenuItem key="5" disabled>5</MenuItem>
           </MenuItemGroup>
-          <SubMenu title="submenu">
+          <SubMenu titleNode={(
+              <span>
+                <span style={{ fontWeight: 600, fontStyle: 'italic' }}>submenu</span>
+              </span>
+            )}
+          >
             <MenuItem key="6">6</MenuItem>
           </SubMenu>
         </Menu>

--- a/tests/__snapshots__/Menu.spec.js.snap
+++ b/tests/__snapshots__/Menu.spec.js.snap
@@ -127,12 +127,19 @@ exports[`Menu should render horizontal menu correctly 1`] = `
   </li>
   <li
     class=" rc-menu-item-group"
+    titlenode="[object Object]"
   >
     <div
       class="rc-menu-item-group-title"
       title="g2"
     >
-      g2
+      <span>
+        <span
+          style="font-weight:600;font-style:italic"
+        >
+          g2
+        </span>
+      </span>
     </div>
     <ul
       class="rc-menu-item-group-list"
@@ -173,14 +180,14 @@ exports[`Menu should render horizontal menu correctly 1`] = `
   <li
     class="rc-menu-submenu rc-menu-submenu-horizontal"
     role="menuitem"
+    titlenode="[object Object]"
   >
     <div
       aria-expanded="false"
       aria-haspopup="true"
       class="rc-menu-submenu-title"
-      title="submenu"
+      title=""
     >
-      submenu
       <i
         class="rc-menu-submenu-arrow"
       />
@@ -253,12 +260,19 @@ exports[`Menu should render inline menu correctly 1`] = `
   </li>
   <li
     class=" rc-menu-item-group"
+    titlenode="[object Object]"
   >
     <div
       class="rc-menu-item-group-title"
       title="g2"
     >
-      g2
+      <span>
+        <span
+          style="font-weight:600;font-style:italic"
+        >
+          g2
+        </span>
+      </span>
     </div>
     <ul
       class="rc-menu-item-group-list"
@@ -283,15 +297,15 @@ exports[`Menu should render inline menu correctly 1`] = `
   <li
     class="rc-menu-submenu rc-menu-submenu-inline"
     role="menuitem"
+    titlenode="[object Object]"
   >
     <div
       aria-expanded="false"
       aria-haspopup="true"
       class="rc-menu-submenu-title"
       style="padding-left:24px"
-      title="submenu"
+      title=""
     >
-      submenu
       <i
         class="rc-menu-submenu-arrow"
       />
@@ -344,12 +358,19 @@ exports[`Menu should render vertical menu correctly 1`] = `
   </li>
   <li
     class=" rc-menu-item-group"
+    titlenode="[object Object]"
   >
     <div
       class="rc-menu-item-group-title"
       title="g2"
     >
-      g2
+      <span>
+        <span
+          style="font-weight:600;font-style:italic"
+        >
+          g2
+        </span>
+      </span>
     </div>
     <ul
       class="rc-menu-item-group-list"
@@ -372,14 +393,14 @@ exports[`Menu should render vertical menu correctly 1`] = `
   <li
     class="rc-menu-submenu rc-menu-submenu-vertical"
     role="menuitem"
+    titlenode="[object Object]"
   >
     <div
       aria-expanded="false"
       aria-haspopup="true"
       class="rc-menu-submenu-title"
-      title="submenu"
+      title=""
     >
-      submenu
       <i
         class="rc-menu-submenu-arrow"
       />


### PR DESCRIPTION
Added a `titleNode` prop to MenuItemGroup that allows you to pass a react node instead of a title. You can still use title as it will be used as the `title` property of the div element.