### PR TITLE
fix: active item cannot be scrolled

### DIFF
--- a/src/MenuItem.jsx
+++ b/src/MenuItem.jsx
@@ -53,7 +53,7 @@ export class MenuItem extends React.Component {
     const { active, parentMenu, eventKey } = this.props;
     // 在 parentMenu 上层保存滚动状态，避免重复的 MenuItem key 导致滚动跳动
     // https://github.com/ant-design/ant-design/issues/16181
-    if (!prevProps.active && active && (!parentMenu && !parentMenu[`scrolled-${eventKey}`])) {
+    if (!prevProps.active && active && (!parentMenu || !parentMenu[`scrolled-${eventKey}`])) {
       if (this.node) {
         scrollIntoView(this.node, ReactDOM.findDOMNode(parentMenu), {
           onlyScrollIfNeeded: true,


### PR DESCRIPTION
问题： 所有 Select 键盘操作都无法滚动到 active item 上了。

close ant-design/ant-design#18939

https://github.com/react-component/menu/commit/452dc7f8665e99c4247cc8fd078e3b868cc088d1