### PR TITLE
added ReactElement type for title prop in MenuItemGroupProps

### DIFF
--- a/src/MenuItemGroup.tsx
+++ b/src/MenuItemGroup.tsx
@@ -13,7 +13,7 @@ export interface MenuItemGroupProps {
   className?: string;
   subMenuKey?: string;
   rootPrefixCls?: string;
-  title?: string | React.ReactNode;
+  title?: React.ReactNode;
   onClick?: MenuClickEventHandler;
 }
 

--- a/src/MenuItemGroup.tsx
+++ b/src/MenuItemGroup.tsx
@@ -13,7 +13,7 @@ export interface MenuItemGroupProps {
   className?: string;
   subMenuKey?: string;
   rootPrefixCls?: string;
-  title?: string;
+  title?: string | React.ReactElement;
   onClick?: MenuClickEventHandler;
 }
 

--- a/src/MenuItemGroup.tsx
+++ b/src/MenuItemGroup.tsx
@@ -13,7 +13,7 @@ export interface MenuItemGroupProps {
   className?: string;
   subMenuKey?: string;
   rootPrefixCls?: string;
-  title?: string | React.ReactElement;
+  title?: string | React.ReactNode;
   onClick?: MenuClickEventHandler;
 }
 


### PR DESCRIPTION
As it is specified in the documentation, the property title of the MenuItemGroup should support string and ReactElement types. This was not the case as just the string type was mentionned.