### PR TITLE
Implemented rtl layout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # rc-menu
+
 ---
 
 react menu component. port from https://github.com/kissyteam/menu
-
 
 [![NPM version][npm-image]][npm-url]
 [![build status][travis-image]][travis-url]
@@ -24,22 +24,23 @@ react menu component. port from https://github.com/kissyteam/menu
 [download-image]: https://img.shields.io/npm/dm/rc-menu.svg?style=flat-square
 [download-url]: https://npmjs.org/package/rc-menu
 
-
 ## Screenshot
 
 ![alt](https://tfsimg.alipay.com/images/T19vReXg0oXXXXXXXX.png)
 
-
 ## Usage
 
 ```jsx
-import Menu, {SubMenu, MenuItem} from 'rc-menu';
-ReactDOM.render(<Menu>
-  <MenuItem>1</MenuItem>
-  <SubMenu title="2">
-  <MenuItem>2-1</MenuItem>
-  </SubMenu>
-</Menu>, container);
+import Menu, { SubMenu, MenuItem } from 'rc-menu';
+ReactDOM.render(
+  <Menu>
+    <MenuItem>1</MenuItem>
+    <SubMenu title="2">
+      <MenuItem>2-1</MenuItem>
+    </SubMenu>
+  </Menu>,
+  container,
+);
 ```
 
 ## install
@@ -204,6 +205,12 @@ ReactDOM.render(<Menu>
             <th></th>
             <td>Specify the menu item icon.</td>
         </tr>
+        <tr>
+            <td>direction</td>
+            <td>String</td>
+            <th></th>
+            <td>Layout direction of menu component, it supports RTL direction too.</td>
+        </tr>
     </tbody>
 </table>
 
@@ -257,7 +264,6 @@ ReactDOM.render(<Menu>
         </tr>
     </tbody>
 </table>
-
 
 ### Menu.SubMenu props
 
@@ -396,7 +402,6 @@ http://localhost:8001/examples/index.md
 
 online example: http://react-component.github.io/menu/examples/
 
-
 ## Test Case
 
 ```
@@ -411,7 +416,6 @@ npm run coverage
 ```
 
 open coverage/ dir
-
 
 ## License
 

--- a/assets/index.less
+++ b/assets/index.less
@@ -337,6 +337,15 @@
       animation-play-state: running;
     }
 
+    &-zoom-enter,
+    &-zoom-appear,
+    &-zoom-leave {
+      .@{menuPrefixCls}-submenu-rtl&,
+      .@{menuPrefixCls}-submenu-rtl & {
+        transform-origin: top right !important;
+      }
+    }
+
     @keyframes rcMenuOpenZoomIn {
       0% {
         opacity: 0;

--- a/assets/index.less
+++ b/assets/index.less
@@ -19,11 +19,16 @@
   outline: none;
   margin-bottom: 0;
   padding-left: 0; // Override default ul/ol
+  padding-right: 0; // Override default ul/ol in RTL direction
   list-style: none;
   border: 1px solid #d9d9d9;
   box-shadow: 0 0 4px #d9d9d9;
   border-radius: 3px;
   color: #666;
+
+  &-rtl {
+    direction: rtl;
+  }
 
   &-hidden {
     display: none;
@@ -83,6 +88,10 @@
     padding: 7px 7px 7px 16px;
     white-space: nowrap;
 
+    .@{menuPrefixCls}-rtl & {
+      padding: 7px 16px 7px 7px;
+    }
+
     // Disabled state sets text to gray and nukes hover/tab effects
     &.@{menuPrefixCls}-item-disabled,
     &.@{menuPrefixCls}-submenu-disabled {
@@ -104,6 +113,11 @@
 
       .submenu-title-wrapper {
         padding-right: 20px;
+
+        .@{menuPrefixCls}-rtl & {
+          padding-right: 0;
+          padding-left: 20px;
+        }
       }
     }
     > .@{menuPrefixCls} {
@@ -118,6 +132,11 @@
       height: 14px;
       margin-right: 8px;
       top: -1px;
+
+      .@{menuPrefixCls}-rtl & {
+        margin-right: 0;
+        margin-left: 8px;
+      }
     }
   }
 
@@ -163,6 +182,10 @@
     & > .@{menuPrefixCls}-item,
     & > .@{menuPrefixCls}-submenu > .@{menuPrefixCls}-submenu-title {
       padding: 12px 8px 12px 24px;
+
+      .@{menuPrefixCls}-rtl& {
+        padding: 12px 24px 12px 8px;
+      }
     }
     .@{menuPrefixCls}-submenu-arrow {
       display: inline-block;
@@ -177,6 +200,17 @@
       line-height: 1.5em;
       &:before {
         content: '\f0da';
+
+        .@{menuPrefixCls}-rtl&,
+        .@{menuPrefixCls}-submenu-rtl & {
+          content: '\f0d9';
+        }
+      }
+
+      .@{menuPrefixCls}-rtl&,
+      .@{menuPrefixCls}-submenu-rtl & {
+        right: auto;
+        left: 16px;
       }
     }
   }
@@ -196,6 +230,10 @@
   &-vertical-left&-sub,
   &-vertical-right&-sub {
     padding: 0;
+
+    .@{menuPrefixCls}-submenu-rtl & {
+      direction: rtl;
+    }
   }
 
   &-sub&-inline {
@@ -209,6 +247,10 @@
       padding-top: 8px;
       padding-bottom: 8px;
       padding-right: 0;
+
+      .@{menuPrefixCls}-rtl & {
+        padding-left: 0;
+      }
     }
   }
 

--- a/examples/rtl-antd.js
+++ b/examples/rtl-antd.js
@@ -1,0 +1,208 @@
+/* eslint-disable no-console, react/require-default-props, no-param-reassign */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import Menu, { SubMenu, Item as MenuItem, Divider } from '../src';
+import '../assets/index.less';
+
+function handleClick(info) {
+  console.log(`clicked ${info.key}`);
+  console.log(info);
+}
+
+const collapseNode = () => ({ height: 0 });
+const expandNode = node => ({ height: node.scrollHeight });
+
+const inlineMotion = {
+  motionName: 'rc-menu-collapse',
+  onAppearStart: collapseNode,
+  onAppearActive: expandNode,
+  onEnterStart: collapseNode,
+  onEnterActive: expandNode,
+  onLeaveStart: expandNode,
+  onLeaveActive: collapseNode,
+};
+
+const nestSubMenu = (
+  <SubMenu
+    title={<span className="submenu-title-wrapper">offset sub menu 2</span>}
+    key="4"
+    popupOffset={[-10, 15]}
+  >
+    <MenuItem key="4-1">inner inner</MenuItem>
+    <Divider />
+    <SubMenu
+      key="4-2"
+      title={<span className="submenu-title-wrapper">sub menu 1</span>}
+    >
+      <SubMenu
+        title={<span className="submenu-title-wrapper">sub 4-2-0</span>}
+        key="4-2-0"
+      >
+        <MenuItem key="4-2-0-1">inner inner</MenuItem>
+        <MenuItem key="4-2-0-2">inner inner2</MenuItem>
+      </SubMenu>
+      <MenuItem key="4-2-1">inn</MenuItem>
+      <SubMenu
+        title={<span className="submenu-title-wrapper">sub menu 4</span>}
+        key="4-2-2"
+      >
+        <MenuItem key="4-2-2-1">inner inner</MenuItem>
+        <MenuItem key="4-2-2-2">inner inner2</MenuItem>
+      </SubMenu>
+      <SubMenu
+        title={<span className="submenu-title-wrapper">sub menu 3</span>}
+        key="4-2-3"
+      >
+        <MenuItem key="4-2-3-1">inner inner</MenuItem>
+        <MenuItem key="4-2-3-2">inner inner2</MenuItem>
+      </SubMenu>
+    </SubMenu>
+  </SubMenu>
+);
+
+function onOpenChange(value) {
+  console.log('onOpenChange', value);
+}
+
+const children1 = [
+  <SubMenu
+    title={<span className="submenu-title-wrapper">sub menu</span>}
+    key="1"
+  >
+    <MenuItem key="1-1">0-1</MenuItem>
+    <MenuItem key="1-2">0-2</MenuItem>
+  </SubMenu>,
+  nestSubMenu,
+  <MenuItem key="2">1</MenuItem>,
+  <MenuItem key="3">outer</MenuItem>,
+  <MenuItem key="5" disabled>
+    disabled
+  </MenuItem>,
+  <MenuItem key="6">outer3</MenuItem>,
+];
+
+const children2 = [
+  <SubMenu
+    title={<span className="submenu-title-wrapper">sub menu</span>}
+    key="1"
+  >
+    <MenuItem key="1-1">0-1</MenuItem>
+    <MenuItem key="1-2">0-2</MenuItem>
+  </SubMenu>,
+  <MenuItem key="2">1</MenuItem>,
+  <MenuItem key="3">outer</MenuItem>,
+];
+
+const customizeIndicator = <span>Add More Items</span>;
+
+class CommonMenu extends React.Component {
+  state = {
+    children: children1,
+    overflowedIndicator: undefined,
+  };
+
+  toggleChildren = () => {
+    this.setState(({ children }) => ({
+      children: children === children1 ? children2 : children1,
+    }));
+  };
+
+  toggleOverflowedIndicator = () => {
+    this.setState(({ overflowedIndicator }) => ({
+      overflowedIndicator:
+        overflowedIndicator === undefined ? customizeIndicator : undefined,
+    }));
+  };
+
+  render() {
+    const { triggerSubMenuAction } = this.props;
+    const { children, overflowedIndicator } = this.state;
+    return (
+      <div>
+        {this.props.updateChildrenAndOverflowedIndicator && (
+          <div>
+            <button type="button" onClick={this.toggleChildren}>
+              toggle children
+            </button>
+            <button type="button" onClick={this.toggleOverflowedIndicator}>
+              toggle overflowedIndicator
+            </button>
+          </div>
+        )}
+        <Menu
+          onClick={handleClick}
+          triggerSubMenuAction={triggerSubMenuAction}
+          onOpenChange={onOpenChange}
+          selectedKeys={['3']}
+          mode={this.props.mode}
+          openAnimation={this.props.openAnimation}
+          defaultOpenKeys={this.props.defaultOpenKeys}
+          overflowedIndicator={overflowedIndicator}
+          motion={this.props.motion}
+          direction="rtl"
+        >
+          {children}
+        </Menu>
+      </div>
+    );
+  }
+}
+
+CommonMenu.propTypes = {
+  mode: PropTypes.string,
+  openAnimation: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  motion: PropTypes.object,
+  triggerSubMenuAction: PropTypes.string,
+  defaultOpenKeys: PropTypes.arrayOf(PropTypes.string),
+  updateChildrenAndOverflowedIndicator: PropTypes.bool,
+};
+
+function Demo() {
+  const horizontalMenu = (
+    <CommonMenu
+      mode="horizontal"
+      // use openTransition for antd
+      openAnimation="slide-up"
+    />
+  );
+
+  const horizontalMenu2 = (
+    <CommonMenu
+      mode="horizontal"
+      // use openTransition for antd
+      openAnimation="slide-up"
+      triggerSubMenuAction="click"
+      updateChildrenAndOverflowedIndicator
+    />
+  );
+
+  const verticalMenu = <CommonMenu mode="vertical" openAnimation="zoom" />;
+
+  const inlineMenu = (
+    <CommonMenu mode="inline" defaultOpenKeys={['1']} motion={inlineMotion} />
+  );
+
+  return (
+    <div style={{ margin: 20, direction: 'rtl' }}>
+      <h2>Rtl antd menu</h2>
+      <div>
+        <h3>horizontal</h3>
+
+        <div style={{ margin: 20 }}>{horizontalMenu}</div>
+        <h3>horizontal and click</h3>
+
+        <div style={{ margin: 20 }}>{horizontalMenu2}</div>
+        <h3>vertical</h3>
+
+        <div style={{ margin: 20, width: 200 }}>{verticalMenu}</div>
+        <h3>inline</h3>
+
+        <div style={{ margin: 20, width: 400 }}>{inlineMenu}</div>
+      </div>
+    </div>
+  );
+}
+
+export default Demo;
+/* eslint-enable */

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -54,7 +54,7 @@ export interface MenuProps
   openAnimation?: OpenAnimation;
 
   /** direction of menu */
-  direction?: 'ltr' | 'rtl' | 'auto';
+  direction?: 'ltr' | 'rtl';
 }
 
 class Menu extends React.Component<MenuProps> {

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -45,7 +45,6 @@ export interface MenuProps
   itemIcon?: RenderIconType;
   expandIcon?: RenderIconType;
   overflowedIndicator?: React.ReactNode;
-
   /** Menu motion define */
   motion?: MotionType;
 
@@ -53,6 +52,9 @@ export interface MenuProps
   openTransitionName?: string;
   /** @deprecated Please use `motion` instead */
   openAnimation?: OpenAnimation;
+
+  /** direction of menu */
+  direction?: 'ltr' | 'rtl' | 'auto';
 }
 
 class Menu extends React.Component<MenuProps> {
@@ -93,6 +95,7 @@ class Menu extends React.Component<MenuProps> {
       selectedKeys,
       openKeys,
       activeKey: { '0-menu-': getActiveKey(props, props.activeKey) },
+      direction: props.direction,
     });
   }
 
@@ -229,6 +232,9 @@ class Menu extends React.Component<MenuProps> {
   render() {
     let props: MenuProps & { parentMenu?: Menu } = { ...this.props };
     props.className += ` ${props.prefixCls}-root`;
+    if (props.direction === 'rtl') {
+      props.className += ` ${props.prefixCls}-rtl`;
+    }
     props = {
       ...props,
       onClick: this.onClick,

--- a/src/MenuItem.tsx
+++ b/src/MenuItem.tsx
@@ -46,6 +46,7 @@ export interface MenuItemProps {
   mode?: MenuMode;
   inlineIndent?: number;
   level?: number;
+  direction?: 'ltr' | 'rtl' | 'auto';
 }
 
 export class MenuItem extends React.Component<MenuItemProps> {
@@ -228,7 +229,12 @@ export class MenuItem extends React.Component<MenuItemProps> {
       ...props.style,
     };
     if (props.mode === 'inline') {
-      style.paddingLeft = props.inlineIndent * props.level;
+      const { direction } = props.store.getState();
+      if (direction === 'rtl') {
+        style.paddingRight = props.inlineIndent * props.level;
+      } else {
+        style.paddingLeft = props.inlineIndent * props.level;
+      }
     }
     menuAllProps.forEach(key => delete props[key]);
     let icon = this.props.itemIcon;
@@ -252,9 +258,10 @@ export class MenuItem extends React.Component<MenuItemProps> {
 }
 
 const connected = connect(
-  ({ activeKey, selectedKeys }, { eventKey, subMenuKey }) => ({
+  ({ activeKey, selectedKeys, direction }, { eventKey, subMenuKey }) => ({
     active: activeKey[subMenuKey] === eventKey,
     isSelected: selectedKeys.indexOf(eventKey) !== -1,
+    direction,
   }),
 )(MenuItem);
 

--- a/src/MenuItem.tsx
+++ b/src/MenuItem.tsx
@@ -46,7 +46,7 @@ export interface MenuItemProps {
   mode?: MenuMode;
   inlineIndent?: number;
   level?: number;
-  direction?: 'ltr' | 'rtl' | 'auto';
+  direction?: 'ltr' | 'rtl';
 }
 
 export class MenuItem extends React.Component<MenuItemProps> {

--- a/src/SubMenu.tsx
+++ b/src/SubMenu.tsx
@@ -6,7 +6,7 @@ import CSSMotion from 'rc-animate/lib/CSSMotion';
 import classNames from 'classnames';
 import { connect } from 'mini-store';
 import SubPopupMenu, { SubPopupMenuProps } from './SubPopupMenu';
-import placements from './placements';
+import { placements, placementsRtl } from './placements';
 import {
   noop,
   loopMenuItemRecursively,
@@ -419,6 +419,7 @@ export class SubMenu extends React.Component<SubMenuProps> {
       manualRef: this.saveMenuInstance,
       itemIcon: props.itemIcon,
       expandIcon: props.expandIcon,
+      direction: props.store.getState().direction,
     };
   };
 
@@ -454,12 +455,16 @@ export class SubMenu extends React.Component<SubMenuProps> {
       return <div />;
     }
 
+    const { direction } = baseProps;
     return (
       <CSSMotion visible={baseProps.visible} {...mergedMotion}>
         {({ className, style }) => {
           const mergedClassName = classNames(
             `${baseProps.prefixCls}-sub`,
             className,
+            {
+              [`${baseProps.prefixCls}-rtl`]: direction && direction === 'rtl',
+            },
           );
 
           return (
@@ -519,8 +524,15 @@ export class SubMenu extends React.Component<SubMenuProps> {
     }
 
     const style: React.CSSProperties = {};
+
+    const { direction } = props.store.getState();
+
     if (isInlineMode) {
-      style.paddingLeft = props.inlineIndent * props.level;
+      if (direction === 'rtl') {
+        style.paddingRight = props.inlineIndent * props.level;
+      } else {
+        style.paddingLeft = props.inlineIndent * props.level;
+      }
     }
 
     let ariaOwns = {};
@@ -572,7 +584,8 @@ export class SubMenu extends React.Component<SubMenuProps> {
       : (triggerNode: HTMLElement) => triggerNode.parentNode;
     const popupPlacement = popupPlacementMap[props.mode];
     const popupAlign = props.popupOffset ? { offset: props.popupOffset } : {};
-    const popupClassName = props.mode === 'inline' ? '' : props.popupClassName;
+    let popupClassName = props.mode === 'inline' ? '' : props.popupClassName;
+    popupClassName += direction === 'rtl' ? ` ${prefixCls}-rtl` : '';
     const {
       disabled,
       triggerSubMenuAction,
@@ -584,7 +597,10 @@ export class SubMenu extends React.Component<SubMenuProps> {
     menuAllProps.forEach(key => delete props[key]);
     // Set onClick to null, to ignore propagated onClick event
     delete props.onClick;
-
+    const placement =
+      direction === 'rtl'
+        ? Object.assign({}, placementsRtl, builtinPlacements)
+        : Object.assign({}, placements, builtinPlacements);
     return (
       <li
         {...(props as any)}
@@ -599,7 +615,7 @@ export class SubMenu extends React.Component<SubMenuProps> {
             prefixCls={prefixCls}
             popupClassName={`${prefixCls}-popup ${popupClassName}`}
             getPopupContainer={getPopupContainer}
-            builtinPlacements={Object.assign({}, placements, builtinPlacements)}
+            builtinPlacements={placement}
             popupPlacement={popupPlacement}
             popupVisible={isOpen}
             popupAlign={popupAlign}

--- a/src/SubPopupMenu.tsx
+++ b/src/SubPopupMenu.tsx
@@ -152,6 +152,8 @@ export interface SubPopupMenuProps {
   // openTransitionName?: string;
   // openAnimation?: OpenAnimation;
   motion?: MotionType;
+
+  direction?: 'ltr' | 'rtl' | 'auto';
 }
 
 export class SubPopupMenu extends React.Component<SubPopupMenuProps> {

--- a/src/SubPopupMenu.tsx
+++ b/src/SubPopupMenu.tsx
@@ -153,7 +153,7 @@ export interface SubPopupMenuProps {
   // openAnimation?: OpenAnimation;
   motion?: MotionType;
 
-  direction?: 'ltr' | 'rtl' | 'auto';
+  direction?: 'ltr' | 'rtl';
 }
 
 export class SubPopupMenu extends React.Component<SubPopupMenuProps> {
@@ -466,10 +466,10 @@ export class SubPopupMenu extends React.Component<SubPopupMenuProps> {
     );
   }
 }
-const connected = connect()(SubPopupMenu) as (React.ComponentClass<
+const connected = connect()(SubPopupMenu) as React.ComponentClass<
   SubPopupMenuProps
 > & {
   getWrappedInstance: () => SubPopupMenu;
-});
+};
 
 export default connected;

--- a/src/placements.ts
+++ b/src/placements.ts
@@ -26,4 +26,27 @@ export const placements = {
   },
 };
 
+export const placementsRtl = {
+  topLeft: {
+    points: ['bl', 'tl'],
+    overflow: autoAdjustOverflow,
+    offset: [0, -7],
+  },
+  bottomLeft: {
+    points: ['tl', 'bl'],
+    overflow: autoAdjustOverflow,
+    offset: [0, 7],
+  },
+  rightTop: {
+    points: ['tr', 'tl'],
+    overflow: autoAdjustOverflow,
+    offset: [-4, 0],
+  },
+  leftTop: {
+    points: ['tl', 'tr'],
+    overflow: autoAdjustOverflow,
+    offset: [4, 0],
+  },
+};
+
 export default placements;

--- a/tests/Menu.spec.js
+++ b/tests/Menu.spec.js
@@ -54,10 +54,16 @@ describe('Menu', () => {
         ).not.toThrow();
       });
 
-      it(`${mode} menu with rtl direction`, () => {
-        expect(() =>
-          render(<Menu mode={mode} direction="rtl" />),
-        ).toMatchSnapshot();
+      it(`${mode} menu with rtl direction correctly`, () => {
+        const wrapper = mount(createMenu({ mode, direction: 'rtl' }));
+        expect(renderToJson(render(wrapper))).toMatchSnapshot();
+
+        expect(
+          wrapper
+            .find('ul')
+            .first()
+            .props().className,
+        ).toContain('-rtl');
       });
     });
   });

--- a/tests/Menu.spec.js
+++ b/tests/Menu.spec.js
@@ -53,6 +53,12 @@ describe('Menu', () => {
           ),
         ).not.toThrow();
       });
+
+      it(`${mode} menu with rtl direction`, () => {
+        expect(() =>
+          render(<Menu mode={mode} direction="rtl" />),
+        ).toMatchSnapshot();
+      });
     });
   });
 

--- a/tests/__snapshots__/Menu.spec.js.snap
+++ b/tests/__snapshots__/Menu.spec.js.snap
@@ -207,7 +207,188 @@ exports[`Menu should render horizontal menu correctly 1`] = `
 </ul>
 `;
 
-exports[`Menu should render horizontal menu with rtl direction 1`] = `[Function]`;
+exports[`Menu should render horizontal menu with rtl direction correctly 1`] = `
+<ul
+  class="rc-menu myMenu rc-menu-root rc-menu-rtl rc-menu-horizontal"
+  direction="rtl"
+  role="menu"
+  tabindex="0"
+>
+  <li
+    class="rc-menu-submenu rc-menu-submenu-horizontal rc-menu-overflowed-submenu"
+    role="menuitem"
+    style="display:none"
+  >
+    <div
+      aria-expanded="false"
+      aria-haspopup="true"
+      class="rc-menu-submenu-title"
+    >
+      <span>
+        ···
+      </span>
+      <i
+        class="rc-menu-submenu-arrow"
+      />
+    </div>
+  </li>
+  <li
+    class=" rc-menu-item-group"
+  >
+    <div
+      class="rc-menu-item-group-title"
+      title="g1"
+    >
+      g1
+    </div>
+    <ul
+      class="rc-menu-item-group-list"
+    >
+      <li
+        class="rc-menu-item"
+        direction="rtl"
+        role="menuitem"
+      >
+        1
+      </li>
+      <li
+        class=" rc-menu-item-divider"
+      />
+      <li
+        class="rc-menu-item"
+        direction="rtl"
+        role="menuitem"
+      >
+        2
+      </li>
+    </ul>
+  </li>
+  <li
+    class="rc-menu-submenu rc-menu-submenu-horizontal rc-menu-overflowed-submenu"
+    role="menuitem"
+    style="display:none"
+  >
+    <div
+      aria-expanded="false"
+      aria-haspopup="true"
+      class="rc-menu-submenu-title"
+    >
+      <span>
+        ···
+      </span>
+      <i
+        class="rc-menu-submenu-arrow"
+      />
+    </div>
+  </li>
+  <li
+    class="rc-menu-item"
+    direction="rtl"
+    role="menuitem"
+  >
+    3
+  </li>
+  <li
+    class="rc-menu-submenu rc-menu-submenu-horizontal rc-menu-overflowed-submenu"
+    role="menuitem"
+    style="display:none"
+  >
+    <div
+      aria-expanded="false"
+      aria-haspopup="true"
+      class="rc-menu-submenu-title"
+    >
+      <span>
+        ···
+      </span>
+      <i
+        class="rc-menu-submenu-arrow"
+      />
+    </div>
+  </li>
+  <li
+    class=" rc-menu-item-group"
+  >
+    <div
+      class="rc-menu-item-group-title"
+      title="g2"
+    >
+      g2
+    </div>
+    <ul
+      class="rc-menu-item-group-list"
+    >
+      <li
+        class="rc-menu-item"
+        direction="rtl"
+        role="menuitem"
+      >
+        4
+      </li>
+      <li
+        aria-disabled="true"
+        class="rc-menu-item rc-menu-item-disabled"
+        direction="rtl"
+        role="menuitem"
+      >
+        5
+      </li>
+    </ul>
+  </li>
+  <li
+    class="rc-menu-submenu rc-menu-submenu-horizontal rc-menu-overflowed-submenu"
+    role="menuitem"
+    style="display:none"
+  >
+    <div
+      aria-expanded="false"
+      aria-haspopup="true"
+      class="rc-menu-submenu-title"
+    >
+      <span>
+        ···
+      </span>
+      <i
+        class="rc-menu-submenu-arrow"
+      />
+    </div>
+  </li>
+  <li
+    class="rc-menu-submenu rc-menu-submenu-horizontal"
+    role="menuitem"
+  >
+    <div
+      aria-expanded="false"
+      aria-haspopup="true"
+      class="rc-menu-submenu-title"
+      title="submenu"
+    >
+      submenu
+      <i
+        class="rc-menu-submenu-arrow"
+      />
+    </div>
+  </li>
+  <li
+    class="rc-menu-submenu rc-menu-submenu-horizontal rc-menu-overflowed-submenu"
+    role="menuitem"
+    style="visibility:hidden;position:absolute"
+  >
+    <div
+      aria-expanded="false"
+      aria-haspopup="true"
+      class="rc-menu-submenu-title"
+    >
+      <span>
+        ···
+      </span>
+      <i
+        class="rc-menu-submenu-arrow"
+      />
+    </div>
+  </li>
+</ul>
+`;
 
 exports[`Menu should render inline menu correctly 1`] = `
 <ul
@@ -303,7 +484,105 @@ exports[`Menu should render inline menu correctly 1`] = `
 </ul>
 `;
 
-exports[`Menu should render inline menu with rtl direction 1`] = `[Function]`;
+exports[`Menu should render inline menu with rtl direction correctly 1`] = `
+<ul
+  class="rc-menu myMenu rc-menu-root rc-menu-rtl rc-menu-inline"
+  direction="rtl"
+  role="menu"
+  tabindex="0"
+>
+  <li
+    class=" rc-menu-item-group"
+  >
+    <div
+      class="rc-menu-item-group-title"
+      title="g1"
+    >
+      g1
+    </div>
+    <ul
+      class="rc-menu-item-group-list"
+    >
+      <li
+        class="rc-menu-item"
+        direction="rtl"
+        role="menuitem"
+        style="padding-right:24px"
+      >
+        1
+      </li>
+      <li
+        class=" rc-menu-item-divider"
+      />
+      <li
+        class="rc-menu-item"
+        direction="rtl"
+        role="menuitem"
+        style="padding-right:24px"
+      >
+        2
+      </li>
+    </ul>
+  </li>
+  <li
+    class="rc-menu-item"
+    direction="rtl"
+    role="menuitem"
+    style="padding-right:24px"
+  >
+    3
+  </li>
+  <li
+    class=" rc-menu-item-group"
+  >
+    <div
+      class="rc-menu-item-group-title"
+      title="g2"
+    >
+      g2
+    </div>
+    <ul
+      class="rc-menu-item-group-list"
+    >
+      <li
+        class="rc-menu-item"
+        direction="rtl"
+        role="menuitem"
+        style="padding-right:24px"
+      >
+        4
+      </li>
+      <li
+        aria-disabled="true"
+        class="rc-menu-item rc-menu-item-disabled"
+        direction="rtl"
+        role="menuitem"
+        style="padding-right:24px"
+      >
+        5
+      </li>
+    </ul>
+  </li>
+  <li
+    class="rc-menu-submenu rc-menu-submenu-inline"
+    role="menuitem"
+  >
+    <div
+      aria-expanded="false"
+      aria-haspopup="true"
+      class="rc-menu-submenu-title"
+      style="padding-right:24px"
+      title="submenu"
+    >
+      submenu
+      <i
+        class="rc-menu-submenu-arrow"
+      />
+    </div>
+    <div />
+  </li>
+</ul>
+`;
 
 exports[`Menu should render vertical menu correctly 1`] = `
 <ul
@@ -392,4 +671,95 @@ exports[`Menu should render vertical menu correctly 1`] = `
 </ul>
 `;
 
-exports[`Menu should render vertical menu with rtl direction 1`] = `[Function]`;
+exports[`Menu should render vertical menu with rtl direction correctly 1`] = `
+<ul
+  class="rc-menu myMenu rc-menu-root rc-menu-rtl rc-menu-vertical"
+  direction="rtl"
+  role="menu"
+  tabindex="0"
+>
+  <li
+    class=" rc-menu-item-group"
+  >
+    <div
+      class="rc-menu-item-group-title"
+      title="g1"
+    >
+      g1
+    </div>
+    <ul
+      class="rc-menu-item-group-list"
+    >
+      <li
+        class="rc-menu-item"
+        direction="rtl"
+        role="menuitem"
+      >
+        1
+      </li>
+      <li
+        class=" rc-menu-item-divider"
+      />
+      <li
+        class="rc-menu-item"
+        direction="rtl"
+        role="menuitem"
+      >
+        2
+      </li>
+    </ul>
+  </li>
+  <li
+    class="rc-menu-item"
+    direction="rtl"
+    role="menuitem"
+  >
+    3
+  </li>
+  <li
+    class=" rc-menu-item-group"
+  >
+    <div
+      class="rc-menu-item-group-title"
+      title="g2"
+    >
+      g2
+    </div>
+    <ul
+      class="rc-menu-item-group-list"
+    >
+      <li
+        class="rc-menu-item"
+        direction="rtl"
+        role="menuitem"
+      >
+        4
+      </li>
+      <li
+        aria-disabled="true"
+        class="rc-menu-item rc-menu-item-disabled"
+        direction="rtl"
+        role="menuitem"
+      >
+        5
+      </li>
+    </ul>
+  </li>
+  <li
+    class="rc-menu-submenu rc-menu-submenu-vertical"
+    role="menuitem"
+  >
+    <div
+      aria-expanded="false"
+      aria-haspopup="true"
+      class="rc-menu-submenu-title"
+      title="submenu"
+    >
+      submenu
+      <i
+        class="rc-menu-submenu-arrow"
+      />
+    </div>
+  </li>
+</ul>
+`;

--- a/tests/__snapshots__/Menu.spec.js.snap
+++ b/tests/__snapshots__/Menu.spec.js.snap
@@ -207,6 +207,8 @@ exports[`Menu should render horizontal menu correctly 1`] = `
 </ul>
 `;
 
+exports[`Menu should render horizontal menu with rtl direction 1`] = `[Function]`;
+
 exports[`Menu should render inline menu correctly 1`] = `
 <ul
   class="rc-menu myMenu rc-menu-root rc-menu-inline"
@@ -301,6 +303,8 @@ exports[`Menu should render inline menu correctly 1`] = `
 </ul>
 `;
 
+exports[`Menu should render inline menu with rtl direction 1`] = `[Function]`;
+
 exports[`Menu should render vertical menu correctly 1`] = `
 <ul
   class="rc-menu myMenu rc-menu-root rc-menu-vertical"
@@ -387,3 +391,5 @@ exports[`Menu should render vertical menu correctly 1`] = `
   </li>
 </ul>
 `;
+
+exports[`Menu should render vertical menu with rtl direction 1`] = `[Function]`;


### PR DESCRIPTION
Rtl layout support for menu component. as this component used in ant-design and i'm working on [ant-desing rtl repo](https://github.com/ant-design/ant-design/pull/19380) to make ant-design support rtl direction.
Please review and merge these changes as soon as possible, so i can include it in rtl implementation of ant-design.

changes the menu direction with `direction='rtl'` property.
- added some tests.
- added rtl demo
- updated readme