### PR TITLE
refactor: move features from menu of antd(#24975)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@babel/runtime": "^7.10.1",
     "classnames": "2.x",
     "mini-store": "^3.0.1",
+    "omit.js": "^1.0.2",
     "rc-animate": "^3.1.0",
     "rc-trigger": "^4.2.0",
     "rc-util": "^5.0.1",

--- a/src/utils/legacyUtil.ts
+++ b/src/utils/legacyUtil.ts
@@ -3,17 +3,26 @@ import { MotionType, TransitionNameType, OpenAnimation } from '../interface';
 
 interface GetMotionProps {
   motion?: MotionType;
+  defaultMotion?: MotionType;
   openAnimation?: OpenAnimation;
   openTransitionName?: TransitionNameType;
   prefixCls?: string;
 }
 
-export function getMotion({
-  prefixCls,
-  motion,
-  openAnimation,
-  openTransitionName,
-}: GetMotionProps): MotionType {
+interface GetMotionState {
+  switchingModeFromInline: boolean;
+}
+
+export function getMotion(
+  {
+    prefixCls,
+    motion,
+    defaultMotion,
+    openAnimation,
+    openTransitionName,
+  }: GetMotionProps,
+  { switchingModeFromInline }: GetMotionState,
+): MotionType {
   if (motion) {
     return motion;
   }
@@ -35,5 +44,7 @@ export function getMotion({
     };
   }
 
-  return null;
+  // When mode switch from inline
+  // submenu should hide without animation
+  return switchingModeFromInline ? null : defaultMotion;
 }

--- a/tests/Menu.spec.js
+++ b/tests/Menu.spec.js
@@ -5,6 +5,7 @@ import { renderToJson } from 'enzyme-to-json';
 import KeyCode from 'rc-util/lib/KeyCode';
 import Menu, { MenuItem, MenuItemGroup, SubMenu, Divider } from '../src';
 import * as mockedUtil from '../src/util';
+import { getMotion } from '../src/utils/legacyUtil';
 
 describe('Menu', () => {
   describe('should render', () => {
@@ -638,6 +639,363 @@ describe('Menu', () => {
           display: 'none',
         });
       });
+    });
+  });
+
+  describe('motion', () => {
+    it('defaultMotion should work correctly', () => {
+      const wrapper = mount(
+        <Menu mode="inline" defaultMotion={{ motionName: 'defaultMotion1' }} />,
+      );
+      expect(getMotion(wrapper.props(), wrapper.state())).toEqual({
+        motionName: 'defaultMotion1',
+      });
+    });
+
+    it('get correct animation type when switched from inline', () => {
+      const wrapper = mount(<Menu mode="inline" />);
+      wrapper.setProps({ mode: 'horizontal' });
+      expect(getMotion(wrapper.props(), wrapper.state())).toEqual(null);
+    });
+
+    it('warning if use `openAnimation` as object', () => {
+      const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      mount(<Menu openAnimation={{}} />);
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Warning: Object type of `openAnimation` is removed. Please use `motion` instead.',
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('motion object', () => {
+      const motion = { test: true };
+      const wrapper = mount(<Menu motion={motion} />);
+      expect(getMotion(wrapper.props(), wrapper.state())).toEqual(motion);
+    });
+
+    it('legacy openTransitionName', () => {
+      const wrapper = mount(<Menu openTransitionName="legacy" />);
+      expect(getMotion(wrapper.props(), wrapper.state())).toEqual({
+        motionName: 'legacy',
+      });
+    });
+  });
+
+  it('onMouseEnter should work', () => {
+    const onMouseEnter = jest.fn();
+    const wrapper = mount(
+      <Menu onMouseEnter={onMouseEnter} defaultSelectedKeys={['test1']}>
+        <MenuItem key="test1">Navigation One</MenuItem>
+        <MenuItem key="test2">Navigation Two</MenuItem>
+      </Menu>,
+    );
+    wrapper
+      .find(Menu)
+      .at(0)
+      .simulate('mouseenter');
+    expect(onMouseEnter).toHaveBeenCalled();
+  });
+
+  describe('inlineCollapse and siderCollapsed', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should always follow openKeys when mode is switched', () => {
+      const wrapper = mount(
+        <Menu openKeys={['1']} mode="inline">
+          <SubMenu key="1" title="submenu1">
+            <MenuItem key="submenu1">Option 1</MenuItem>
+            <MenuItem key="submenu2">Option 2</MenuItem>
+          </SubMenu>
+          <MenuItem key="2">menu2</MenuItem>
+        </Menu>,
+      );
+      expect(
+        wrapper
+          .find('ul.rc-menu-sub')
+          .at(0)
+          .hasClass('rc-menu-hidden'),
+      ).toBe(false);
+      wrapper.setProps({ mode: 'vertical' });
+      expect(
+        wrapper
+          .find('ul.rc-menu-sub')
+          .at(0)
+          .hasClass('rc-menu-hidden'),
+      ).toBe(false);
+      wrapper.setProps({ mode: 'inline' });
+      expect(
+        wrapper
+          .find('ul.rc-menu-sub')
+          .at(0)
+          .hasClass('rc-menu-hidden'),
+      ).toBe(false);
+    });
+
+    it('should always follow openKeys when inlineCollapsed is switched', () => {
+      const wrapper = mount(
+        <Menu defaultOpenKeys={['1']} mode="inline">
+          <MenuItem key="menu1">
+            <span>Option</span>
+          </MenuItem>
+          <SubMenu key="1" title="submenu1">
+            <MenuItem key="submenu1">Option</MenuItem>
+            <MenuItem key="submenu2">Option</MenuItem>
+          </SubMenu>
+        </Menu>,
+      );
+      expect(
+        wrapper
+          .find('ul.rc-menu-sub')
+          .at(0)
+          .hasClass('rc-menu-inline'),
+      ).toBe(true);
+      expect(
+        wrapper
+          .find('ul.rc-menu-sub')
+          .at(0)
+          .hasClass('rc-menu-hidden'),
+      ).toBe(false);
+
+      wrapper.setProps({ inlineCollapsed: true });
+      // 动画结束后套样式;
+      jest.runAllTimers();
+      wrapper.update();
+      wrapper.simulate('transitionEnd', { propertyName: 'width' });
+
+      expect(
+        wrapper
+          .find('ul.rc-menu-root')
+          .at(0)
+          .hasClass('rc-menu-vertical'),
+      ).toBe(true);
+      expect(wrapper.find('ul.rc-menu-sub').length).toBe(0);
+
+      wrapper.setProps({ inlineCollapsed: false });
+      jest.runAllTimers();
+      wrapper.update();
+
+      expect(
+        wrapper
+          .find('ul.rc-menu-sub')
+          .at(0)
+          .hasClass('rc-menu-inline'),
+      ).toBe(true);
+      expect(
+        wrapper
+          .find('ul.rc-menu-sub')
+          .at(0)
+          .hasClass('rc-menu-hidden'),
+      ).toBe(false);
+    });
+
+    it('inlineCollapsed should works well when specify a not existed default openKeys', () => {
+      const wrapper = mount(
+        <Menu defaultOpenKeys={['not-existed']} mode="inline">
+          <MenuItem key="menu1">
+            <span>Option</span>
+          </MenuItem>
+          <SubMenu key="1" title="submenu1">
+            <MenuItem key="submenu1">Option</MenuItem>
+            <MenuItem key="submenu2">Option</MenuItem>
+          </SubMenu>
+        </Menu>,
+      );
+      expect(wrapper.find('.rc-menu-sub').length).toBe(0);
+      wrapper.setProps({ inlineCollapsed: true });
+      jest.runAllTimers();
+      wrapper.update();
+      wrapper.simulate('transitionEnd', { propertyName: 'width' });
+      wrapper
+        .find('.rc-menu-submenu-title')
+        .at(0)
+        .simulate('mouseEnter');
+      jest.runAllTimers();
+      wrapper.update();
+      expect(
+        wrapper
+          .find('.rc-menu-submenu')
+          .at(0)
+          .hasClass('rc-menu-submenu-vertical'),
+      ).toBe(true);
+      expect(
+        wrapper
+          .find('.rc-menu-submenu')
+          .at(0)
+          .hasClass('rc-menu-submenu-open'),
+      ).toBe(true);
+      expect(
+        wrapper
+          .find('ul.rc-menu-sub')
+          .at(0)
+          .hasClass('rc-menu-vertical'),
+      ).toBe(true);
+      expect(
+        wrapper
+          .find('ul.rc-menu-sub')
+          .at(0)
+          .hasClass('rc-menu-hidden'),
+      ).toBe(false);
+    });
+
+    it('inlineCollapsed MenuItem Tooltip can be removed', () => {
+      const wrapper = mount(
+        <Menu
+          defaultOpenKeys={['not-existed']}
+          mode="inline"
+          inlineCollapsed
+          getPopupContainer={node => node.parentNode}
+        >
+          <MenuItem key="menu1">item</MenuItem>
+          <MenuItem key="menu2" title="title">
+            item
+          </MenuItem>
+          <MenuItem key="menu3" title={undefined}>
+            item
+          </MenuItem>
+          <MenuItem key="menu4" title={null}>
+            item
+          </MenuItem>
+          <MenuItem key="menu5" title="">
+            item
+          </MenuItem>
+          <MenuItem key="menu6" title={false}>
+            item
+          </MenuItem>
+        </Menu>,
+      );
+      expect(
+        wrapper
+          .find(MenuItem)
+          .at(0)
+          .getDOMNode().title,
+      ).toBe('');
+      expect(
+        wrapper
+          .find(MenuItem)
+          .at(1)
+          .getDOMNode().title,
+      ).toBe('title');
+      expect(
+        wrapper
+          .find(MenuItem)
+          .at(2)
+          .getDOMNode().title,
+      ).toBe('');
+      expect(
+        wrapper
+          .find(MenuItem)
+          .at(3)
+          .getDOMNode().title,
+      ).toBe('');
+      expect(
+        wrapper
+          .find(MenuItem)
+          .at(4)
+          .getDOMNode().title,
+      ).toBe('');
+      expect(
+        wrapper
+          .find(MenuItem)
+          .at(4)
+          .getDOMNode().title,
+      ).toBe('');
+    });
+
+    it('should use siderCollapsed when siderCollapsed is passed', () => {
+      const wrapper = mount(
+        <Menu
+          openKeys={['1']}
+          mode="inline"
+          inlineCollapsed
+          siderCollapsed={false}
+        >
+          <SubMenu key="1" title="submenu1">
+            <MenuItem key="submenu1">Option 1</MenuItem>
+            <MenuItem key="submenu2">Option 2</MenuItem>
+          </SubMenu>
+          <MenuItem key="2">menu2</MenuItem>
+        </Menu>,
+      );
+      expect(wrapper.instance().getInlineCollapsed()).toBe(false);
+    });
+
+    // https://github.com/ant-design/ant-design/issues/18825
+    // https://github.com/ant-design/ant-design/issues/8587
+    it('should keep selectedKeys in state when collapsed to 0px', () => {
+      const wrapper = mount(
+        <Menu
+          mode="inline"
+          inlineCollapsed={false}
+          defaultSelectedKeys={['1']}
+          collapsedWidth={0}
+          openKeys={['3']}
+        >
+          <MenuItem key="1">Option 1</MenuItem>
+          <MenuItem key="2">Option 2</MenuItem>
+          <SubMenu key="3" title="Option 3">
+            <MenuItem key="4">Option 4</MenuItem>
+          </SubMenu>
+        </Menu>,
+      );
+      expect(
+        wrapper.find('.rc-menu-item-selected').getDOMNode().textContent,
+      ).toBe('Option 1');
+      wrapper
+        .find('.rc-menu-item')
+        .at(1)
+        .simulate('click');
+      expect(
+        wrapper.find('.rc-menu-item-selected').getDOMNode().textContent,
+      ).toBe('Option 2');
+      wrapper.setProps({ inlineCollapsed: true });
+      jest.runAllTimers();
+      wrapper.update();
+      expect(
+        wrapper
+          .find('Trigger')
+          .map(node => node.prop('popupVisible'))
+          .findIndex(node => !!node),
+      ).toBe(-1);
+      wrapper.setProps({ inlineCollapsed: false });
+      expect(
+        wrapper.find('.rc-menu-item-selected').getDOMNode().textContent,
+      ).toBe('Option 2');
+    });
+
+    it('should hideMenu in initial state  when collapsed to 0px', () => {
+      const wrapper = mount(
+        <Menu
+          mode="inline"
+          inlineCollapsed
+          defaultSelectedKeys={['1']}
+          collapsedWidth={0}
+          openKeys={['3']}
+        >
+          <MenuItem key="1">Option 1</MenuItem>
+          <MenuItem key="2">Option 2</MenuItem>
+          <SubMenu key="3" title="Option 3">
+            <MenuItem key="4">Option 4</MenuItem>
+          </SubMenu>
+        </Menu>,
+      );
+      expect(
+        wrapper
+          .find('Trigger')
+          .map(node => node.prop('popupVisible'))
+          .findIndex(node => !!node),
+      ).toBe(-1);
+      wrapper.setProps({ inlineCollapsed: false });
+      jest.runAllTimers();
+      wrapper.update();
+      expect(
+        wrapper.find('.rc-menu-item-selected').getDOMNode().textContent,
+      ).toBe('Option 1');
     });
   });
 });


### PR DESCRIPTION
[#24975](https://github.com/ant-design/ant-design/issues/24975)

将 antd 的 menu 中的功能移植过来，自己做状态管理，使其中的 `mini-store` 做的优化渲染在 antd 中生效。

@afc163 @zombieJ 看看有没有遗漏的？