### PR TITLE
fix: typeof openKeys can be React.Key

### DIFF
--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -22,9 +22,9 @@ export interface MenuProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onClick' | 'onSelect'> {
   defaultSelectedKeys?: string[];
   defaultActiveFirst?: boolean;
-  selectedKeys?: string[];
-  defaultOpenKeys?: string[];
-  openKeys?: string[];
+  selectedKeys?: React.Key[];
+  defaultOpenKeys?: React.Key[];
+  openKeys?: React.Key[];
   mode?: MenuMode;
   getPopupContainer?: (node: HTMLElement) => HTMLElement;
   onClick?: MenuClickEventHandler;


### PR DESCRIPTION
when get keys in onOpenChange to set openKeys, type mismatch. maybe use React.Key is better.