### PR TITLE
lower level triggerSubMenuAction wins over upper level triggerSubMenuAction

### DIFF
--- a/src/SubPopupMenu.tsx
+++ b/src/SubPopupMenu.tsx
@@ -412,7 +412,9 @@ export class SubPopupMenu extends React.Component<SubPopupMenuProps> {
     const extraProps = {
       openKeys: state.openKeys,
       selectedKeys: state.selectedKeys,
-      triggerSubMenuAction: this.props.triggerSubMenuAction,
+      triggerSubMenuAction: c.props?.triggerSubMenuAction ?
+        c.props.triggerSubMenuAction :
+        this.props.triggerSubMenuAction,
       subMenuKey,
     };
     return this.renderCommonMenuItem(c, i, extraProps);


### PR DESCRIPTION
to cater for scenario where top level items are `click` and sub menus are `hover` - similar to google docs menu UX