### PR TITLE
Introduced a remainOnSelect property

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ ReactDOM.render(
             <td>whether allow multiple select</td>
         </tr>
         <tr>
+            <td>remainOnSelect</td>
+            <td>Boolean</td>
+            <th>false</th>
+            <td>whether to allow the menu to remain showing after an item is selected</td>
+        </tr>
+        <tr>
             <td>selectable</td>
             <td>Boolean</td>
             <th>true</th>

--- a/docs/examples/multiple.tsx
+++ b/docs/examples/multiple.tsx
@@ -27,6 +27,7 @@ function Demo() {
       onSelect={handleSelect}
       onDeselect={handleDeselect}
       defaultSelectedKeys={['2', '1-1']}
+      remainOnSelect
     >
       <SubMenu title={titleRight} key="1">
         <MenuItem key="1-1">0-1</MenuItem>

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -245,7 +245,7 @@ class Menu extends React.Component<MenuProps, MenuState> {
       props: { onOpenChange },
     } = this;
 
-    if (mode !== 'inline' && !('openKeys' in this.props) && !('remainOnSelect' in this.props)) {
+    if (mode !== 'inline' && !('openKeys' in this.props) && !(this.props.remainOnSelect)) {
       // closing vertical popup submenu after click it
       store.setState({
         openKeys: [],

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -61,6 +61,9 @@ export interface MenuProps
 
   inlineCollapsed?: boolean;
 
+  /** allow the menu to remain active after an item is selected. */
+  remainOnSelect?: boolean;
+
   /** SiderContextProps of layout in ant design */
   siderCollapsed?: boolean;
   collapsedWidth?: string | number;
@@ -242,7 +245,7 @@ class Menu extends React.Component<MenuProps, MenuState> {
       props: { onOpenChange },
     } = this;
 
-    if (mode !== 'inline' && !('openKeys' in this.props)) {
+    if (mode !== 'inline' && !('openKeys' in this.props) && !('remainOnSelect' in this.props)) {
       // closing vertical popup submenu after click it
       store.setState({
         openKeys: [],


### PR DESCRIPTION
When added to a Menu, a new  "remainOnSelect" property allows the menu to remain active even after the user selects an item.
This should be particularly useful for multi-select scenarios.