### PR TITLE
fix: keyPath is inverse

### DIFF
--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -535,12 +535,12 @@ const Menu: React.FC<MenuProps> = props => {
           {container}
         </PathUserContext.Provider>
 
-        {/* Measure menu keys */}
-        {/* <div style={{ display: 'none' }} aria-hidden> */}
-        <PathRegisterContext.Provider value={registerPathContext}>
-          {childList}
-        </PathRegisterContext.Provider>
-        {/* </div> */}
+        {/* Measure menu keys. Add `display: none` to avoid some developer miss use the Menu */}
+        <div style={{ display: 'none' }} aria-hidden>
+          <PathRegisterContext.Provider value={registerPathContext}>
+            {childList}
+          </PathRegisterContext.Provider>
+        </div>
       </MenuContextProvider>
     </IdContext.Provider>
   );

--- a/src/MenuItem.tsx
+++ b/src/MenuItem.tsx
@@ -135,7 +135,8 @@ const InternalMenuItem = (props: MenuItemProps) => {
   ): MenuInfo => {
     return {
       key: eventKey,
-      keyPath: connectedKeys,
+      // Note: For legacy code is reversed which not like other antd component
+      keyPath: [...connectedKeys].reverse(),
       item: legacyMenuItemRef.current,
       domEvent: e,
     };

--- a/tests/Menu.spec.js
+++ b/tests/Menu.spec.js
@@ -331,18 +331,29 @@ describe('Menu', () => {
   });
 
   it('fires click event', () => {
+    jest.useFakeTimers();
+
     resetWarned();
 
     const errorSpy = jest.spyOn(console, 'error');
 
     const handleClick = jest.fn();
     const wrapper = mount(
-      <Menu onClick={handleClick}>
+      <Menu onClick={handleClick} openKeys={['parent']}>
         <MenuItem key="1">1</MenuItem>
         <MenuItem key="2">2</MenuItem>
+        <Menu.SubMenu key="parent">
+          <MenuItem key="3">3</MenuItem>
+        </Menu.SubMenu>
       </Menu>,
     );
-    wrapper.find('MenuItem').first().simulate('click');
+
+    act(() => {
+      jest.runAllTimers();
+      wrapper.update();
+    });
+
+    wrapper.find('.rc-menu-item').first().simulate('click');
     const info = handleClick.mock.calls[0][0];
     expect(info.key).toBe('1');
     expect(info.item).toBeTruthy();
@@ -351,7 +362,13 @@ describe('Menu', () => {
       'Warning: `info.item` is deprecated since we will move to function component that not provides React Node instance in future.',
     );
 
+    handleClick.mockReset();
+    wrapper.find('.rc-menu-item').last().simulate('click');
+    expect(handleClick.mock.calls[0][0].keyPath).toEqual(['3', 'parent']);
+
     errorSpy.mockRestore();
+
+    jest.useRealTimers();
   });
 
   it('fires deselect event', () => {

--- a/tests/__snapshots__/Keyboard.spec.tsx.snap
+++ b/tests/__snapshots__/Keyboard.spec.tsx.snap
@@ -1,43 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Menu.Keyboard no data-menu-id by init 1`] = `
-<ul
-  class="rc-menu rc-menu-root rc-menu-inline"
-  data-menu-list="true"
-  role="menu"
-  tabindex="0"
->
-  <li
-    class="rc-menu-submenu rc-menu-submenu-inline rc-menu-submenu-open"
-    role="none"
+Array [
+  <ul
+    class="rc-menu rc-menu-root rc-menu-inline"
+    data-menu-list="true"
+    role="menu"
+    tabindex="0"
   >
-    <div
-      aria-expanded="true"
-      aria-haspopup="true"
-      class="rc-menu-submenu-title"
-      role="menuitem"
-      style="padding-left:24px"
-      tabindex="-1"
-      title="Light"
+    <li
+      class="rc-menu-submenu rc-menu-submenu-inline rc-menu-submenu-open"
+      role="none"
     >
-      Light
-      <i
-        class="rc-menu-submenu-arrow"
-      />
-    </div>
-    <ul
-      class="rc-menu rc-menu-sub rc-menu-inline"
-      data-menu-list="true"
-    >
-      <li
-        class="rc-menu-item"
+      <div
+        aria-expanded="true"
+        aria-haspopup="true"
+        class="rc-menu-submenu-title"
         role="menuitem"
-        style="padding-left:48px"
+        style="padding-left:24px"
         tabindex="-1"
+        title="Light"
       >
-        Bamboo
-      </li>
-    </ul>
-  </li>
-</ul>
+        Light
+        <i
+          class="rc-menu-submenu-arrow"
+        />
+      </div>
+      <ul
+        class="rc-menu rc-menu-sub rc-menu-inline"
+        data-menu-list="true"
+      >
+        <li
+          class="rc-menu-item"
+          role="menuitem"
+          style="padding-left:48px"
+          tabindex="-1"
+        >
+          Bamboo
+        </li>
+      </ul>
+    </li>
+  </ul>,
+  <div
+    aria-hidden="true"
+    style="display:none"
+  />,
+]
 `;

--- a/tests/__snapshots__/Menu.spec.js.snap
+++ b/tests/__snapshots__/Menu.spec.js.snap
@@ -1,725 +1,773 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Menu render role listbox renders menu correctly 1`] = `
-<ul
-  class="rc-menu rc-menu-root rc-menu-vertical myMenu"
-  data-menu-list="true"
-  role="listbox"
-  tabindex="0"
->
-  <li
-    aria-selected="false"
-    class="rc-menu-item"
-    data-menu-id="rc-menu-uuid-test-1"
-    role="option"
-    tabindex="-1"
+Array [
+  <ul
+    class="rc-menu rc-menu-root rc-menu-vertical myMenu"
+    data-menu-list="true"
+    role="listbox"
+    tabindex="0"
   >
-    1
-  </li>
-  <li
-    aria-selected="false"
-    class="rc-menu-item"
-    data-menu-id="rc-menu-uuid-test-2"
-    role="option"
-    tabindex="-1"
-  >
-    2
-  </li>
-  <li
-    aria-selected="false"
-    class="rc-menu-item"
-    data-menu-id="rc-menu-uuid-test-3"
-    role="option"
-    tabindex="-1"
-  >
-    3
-  </li>
-</ul>
+    <li
+      aria-selected="false"
+      class="rc-menu-item"
+      data-menu-id="rc-menu-uuid-test-1"
+      role="option"
+      tabindex="-1"
+    >
+      1
+    </li>
+    <li
+      aria-selected="false"
+      class="rc-menu-item"
+      data-menu-id="rc-menu-uuid-test-2"
+      role="option"
+      tabindex="-1"
+    >
+      2
+    </li>
+    <li
+      aria-selected="false"
+      class="rc-menu-item"
+      data-menu-id="rc-menu-uuid-test-3"
+      role="option"
+      tabindex="-1"
+    >
+      3
+    </li>
+  </ul>,
+  <div
+    aria-hidden="true"
+    style="display: none;"
+  />,
+]
 `;
 
 exports[`Menu should render horizontal menu correctly 1`] = `
-<ul
-  class="rc-menu rc-menu-root rc-menu-horizontal myMenu"
-  data-menu-list="true"
-  role="menu"
-  tabindex="0"
->
-  <li
-    class="rc-menu-item-group"
+Array [
+  <ul
+    class="rc-menu rc-menu-root rc-menu-horizontal myMenu"
+    data-menu-list="true"
+    role="menu"
+    tabindex="0"
   >
-    <div
-      class="rc-menu-item-group-title"
-      title="g1"
+    <li
+      class="rc-menu-item-group"
     >
-      g1
-    </div>
-    <ul
-      class="rc-menu-item-group-list"
-    >
-      <li
-        class="rc-menu-item"
-        data-menu-id="rc-menu-uuid-test-1"
-        role="menuitem"
-        tabindex="-1"
+      <div
+        class="rc-menu-item-group-title"
+        title="g1"
       >
-        1
-      </li>
-      <li
-        class="rc-menu-item-divider"
-      />
-      <li
-        class="rc-menu-item"
-        data-menu-id="rc-menu-uuid-test-2"
-        role="menuitem"
-        tabindex="-1"
+        g1
+      </div>
+      <ul
+        class="rc-menu-item-group-list"
       >
-        2
-      </li>
-    </ul>
-  </li>
-  <li
-    class="rc-menu-item"
-    data-menu-id="rc-menu-uuid-test-3"
-    role="menuitem"
-    tabindex="-1"
-  >
-    3
-  </li>
-  <li
-    class="rc-menu-item-group"
-  >
-    <div
-      class="rc-menu-item-group-title"
-      title="g2"
-    >
-      g2
-    </div>
-    <ul
-      class="rc-menu-item-group-list"
-    >
-      <li
-        class="rc-menu-item"
-        data-menu-id="rc-menu-uuid-test-4"
-        role="menuitem"
-        tabindex="-1"
-      >
-        4
-      </li>
-      <li
-        aria-disabled="true"
-        class="rc-menu-item rc-menu-item-disabled"
-        data-menu-id="rc-menu-uuid-test-5"
-        role="menuitem"
-      >
-        5
-      </li>
-    </ul>
-  </li>
-  <li
-    class="rc-menu-submenu rc-menu-submenu-horizontal"
-    role="none"
-  >
-    <div
-      aria-controls="rc-menu-uuid-test-tmp_key-3-popup"
-      aria-expanded="false"
-      aria-haspopup="true"
-      class="rc-menu-submenu-title"
-      data-menu-id="rc-menu-uuid-test-tmp_key-3"
+        <li
+          class="rc-menu-item"
+          data-menu-id="rc-menu-uuid-test-1"
+          role="menuitem"
+          tabindex="-1"
+        >
+          1
+        </li>
+        <li
+          class="rc-menu-item-divider"
+        />
+        <li
+          class="rc-menu-item"
+          data-menu-id="rc-menu-uuid-test-2"
+          role="menuitem"
+          tabindex="-1"
+        >
+          2
+        </li>
+      </ul>
+    </li>
+    <li
+      class="rc-menu-item"
+      data-menu-id="rc-menu-uuid-test-3"
       role="menuitem"
       tabindex="-1"
-      title="submenu"
     >
-      submenu
-      <i
-        class="rc-menu-submenu-arrow"
-      />
-    </div>
-  </li>
-</ul>
+      3
+    </li>
+    <li
+      class="rc-menu-item-group"
+    >
+      <div
+        class="rc-menu-item-group-title"
+        title="g2"
+      >
+        g2
+      </div>
+      <ul
+        class="rc-menu-item-group-list"
+      >
+        <li
+          class="rc-menu-item"
+          data-menu-id="rc-menu-uuid-test-4"
+          role="menuitem"
+          tabindex="-1"
+        >
+          4
+        </li>
+        <li
+          aria-disabled="true"
+          class="rc-menu-item rc-menu-item-disabled"
+          data-menu-id="rc-menu-uuid-test-5"
+          role="menuitem"
+        >
+          5
+        </li>
+      </ul>
+    </li>
+    <li
+      class="rc-menu-submenu rc-menu-submenu-horizontal"
+      role="none"
+    >
+      <div
+        aria-controls="rc-menu-uuid-test-tmp_key-3-popup"
+        aria-expanded="false"
+        aria-haspopup="true"
+        class="rc-menu-submenu-title"
+        data-menu-id="rc-menu-uuid-test-tmp_key-3"
+        role="menuitem"
+        tabindex="-1"
+        title="submenu"
+      >
+        submenu
+        <i
+          class="rc-menu-submenu-arrow"
+        />
+      </div>
+    </li>
+  </ul>,
+  <div
+    aria-hidden="true"
+    style="display: none;"
+  />,
+]
 `;
 
 exports[`Menu should render horizontal menu with rtl direction correctly 1`] = `
-<ul
-  class="rc-menu rc-menu-root rc-menu-horizontal myMenu rc-menu-rtl"
-  data-menu-list="true"
-  dir="rtl"
-  role="menu"
-  tabindex="0"
->
-  <li
-    class="rc-menu-item-group"
+Array [
+  <ul
+    class="rc-menu rc-menu-root rc-menu-horizontal myMenu rc-menu-rtl"
+    data-menu-list="true"
+    dir="rtl"
+    role="menu"
+    tabindex="0"
   >
-    <div
-      class="rc-menu-item-group-title"
-      title="g1"
+    <li
+      class="rc-menu-item-group"
     >
-      g1
-    </div>
-    <ul
-      class="rc-menu-item-group-list"
-    >
-      <li
-        class="rc-menu-item"
-        data-menu-id="rc-menu-uuid-test-1"
-        role="menuitem"
-        tabindex="-1"
+      <div
+        class="rc-menu-item-group-title"
+        title="g1"
       >
-        1
-      </li>
-      <li
-        class="rc-menu-item-divider"
-      />
-      <li
-        class="rc-menu-item"
-        data-menu-id="rc-menu-uuid-test-2"
-        role="menuitem"
-        tabindex="-1"
+        g1
+      </div>
+      <ul
+        class="rc-menu-item-group-list"
       >
-        2
-      </li>
-    </ul>
-  </li>
-  <li
-    class="rc-menu-item"
-    data-menu-id="rc-menu-uuid-test-3"
-    role="menuitem"
-    tabindex="-1"
-  >
-    3
-  </li>
-  <li
-    class="rc-menu-item-group"
-  >
-    <div
-      class="rc-menu-item-group-title"
-      title="g2"
-    >
-      g2
-    </div>
-    <ul
-      class="rc-menu-item-group-list"
-    >
-      <li
-        class="rc-menu-item"
-        data-menu-id="rc-menu-uuid-test-4"
-        role="menuitem"
-        tabindex="-1"
-      >
-        4
-      </li>
-      <li
-        aria-disabled="true"
-        class="rc-menu-item rc-menu-item-disabled"
-        data-menu-id="rc-menu-uuid-test-5"
-        role="menuitem"
-      >
-        5
-      </li>
-    </ul>
-  </li>
-  <li
-    class="rc-menu-submenu rc-menu-submenu-horizontal"
-    role="none"
-  >
-    <div
-      aria-controls="rc-menu-uuid-test-tmp_key-3-popup"
-      aria-expanded="false"
-      aria-haspopup="true"
-      class="rc-menu-submenu-title"
-      data-menu-id="rc-menu-uuid-test-tmp_key-3"
+        <li
+          class="rc-menu-item"
+          data-menu-id="rc-menu-uuid-test-1"
+          role="menuitem"
+          tabindex="-1"
+        >
+          1
+        </li>
+        <li
+          class="rc-menu-item-divider"
+        />
+        <li
+          class="rc-menu-item"
+          data-menu-id="rc-menu-uuid-test-2"
+          role="menuitem"
+          tabindex="-1"
+        >
+          2
+        </li>
+      </ul>
+    </li>
+    <li
+      class="rc-menu-item"
+      data-menu-id="rc-menu-uuid-test-3"
       role="menuitem"
       tabindex="-1"
-      title="submenu"
     >
-      submenu
-      <i
-        class="rc-menu-submenu-arrow"
-      />
-    </div>
-  </li>
-</ul>
+      3
+    </li>
+    <li
+      class="rc-menu-item-group"
+    >
+      <div
+        class="rc-menu-item-group-title"
+        title="g2"
+      >
+        g2
+      </div>
+      <ul
+        class="rc-menu-item-group-list"
+      >
+        <li
+          class="rc-menu-item"
+          data-menu-id="rc-menu-uuid-test-4"
+          role="menuitem"
+          tabindex="-1"
+        >
+          4
+        </li>
+        <li
+          aria-disabled="true"
+          class="rc-menu-item rc-menu-item-disabled"
+          data-menu-id="rc-menu-uuid-test-5"
+          role="menuitem"
+        >
+          5
+        </li>
+      </ul>
+    </li>
+    <li
+      class="rc-menu-submenu rc-menu-submenu-horizontal"
+      role="none"
+    >
+      <div
+        aria-controls="rc-menu-uuid-test-tmp_key-3-popup"
+        aria-expanded="false"
+        aria-haspopup="true"
+        class="rc-menu-submenu-title"
+        data-menu-id="rc-menu-uuid-test-tmp_key-3"
+        role="menuitem"
+        tabindex="-1"
+        title="submenu"
+      >
+        submenu
+        <i
+          class="rc-menu-submenu-arrow"
+        />
+      </div>
+    </li>
+  </ul>,
+  <div
+    aria-hidden="true"
+    style="display: none;"
+  />,
+]
 `;
 
 exports[`Menu should render inline menu correctly 1`] = `
-<ul
-  class="rc-menu rc-menu-root rc-menu-inline myMenu"
-  data-menu-list="true"
-  role="menu"
-  tabindex="0"
->
-  <li
-    class="rc-menu-item-group"
+Array [
+  <ul
+    class="rc-menu rc-menu-root rc-menu-inline myMenu"
+    data-menu-list="true"
+    role="menu"
+    tabindex="0"
   >
-    <div
-      class="rc-menu-item-group-title"
-      title="g1"
+    <li
+      class="rc-menu-item-group"
     >
-      g1
-    </div>
-    <ul
-      class="rc-menu-item-group-list"
-    >
-      <li
-        class="rc-menu-item"
-        data-menu-id="rc-menu-uuid-test-1"
-        role="menuitem"
-        style="padding-left: 24px;"
-        tabindex="-1"
+      <div
+        class="rc-menu-item-group-title"
+        title="g1"
       >
-        1
-      </li>
-      <li
-        class="rc-menu-item-divider"
-      />
-      <li
-        class="rc-menu-item"
-        data-menu-id="rc-menu-uuid-test-2"
-        role="menuitem"
-        style="padding-left: 24px;"
-        tabindex="-1"
+        g1
+      </div>
+      <ul
+        class="rc-menu-item-group-list"
       >
-        2
-      </li>
-    </ul>
-  </li>
-  <li
-    class="rc-menu-item"
-    data-menu-id="rc-menu-uuid-test-3"
-    role="menuitem"
-    style="padding-left: 24px;"
-    tabindex="-1"
-  >
-    3
-  </li>
-  <li
-    class="rc-menu-item-group"
-  >
-    <div
-      class="rc-menu-item-group-title"
-      title="g2"
-    >
-      g2
-    </div>
-    <ul
-      class="rc-menu-item-group-list"
-    >
-      <li
-        class="rc-menu-item"
-        data-menu-id="rc-menu-uuid-test-4"
-        role="menuitem"
-        style="padding-left: 24px;"
-        tabindex="-1"
-      >
-        4
-      </li>
-      <li
-        aria-disabled="true"
-        class="rc-menu-item rc-menu-item-disabled"
-        data-menu-id="rc-menu-uuid-test-5"
-        role="menuitem"
-        style="padding-left: 24px;"
-      >
-        5
-      </li>
-    </ul>
-  </li>
-  <li
-    class="rc-menu-submenu rc-menu-submenu-inline"
-    role="none"
-  >
-    <div
-      aria-controls="rc-menu-uuid-test-tmp_key-3-popup"
-      aria-expanded="false"
-      aria-haspopup="true"
-      class="rc-menu-submenu-title"
-      data-menu-id="rc-menu-uuid-test-tmp_key-3"
+        <li
+          class="rc-menu-item"
+          data-menu-id="rc-menu-uuid-test-1"
+          role="menuitem"
+          style="padding-left: 24px;"
+          tabindex="-1"
+        >
+          1
+        </li>
+        <li
+          class="rc-menu-item-divider"
+        />
+        <li
+          class="rc-menu-item"
+          data-menu-id="rc-menu-uuid-test-2"
+          role="menuitem"
+          style="padding-left: 24px;"
+          tabindex="-1"
+        >
+          2
+        </li>
+      </ul>
+    </li>
+    <li
+      class="rc-menu-item"
+      data-menu-id="rc-menu-uuid-test-3"
       role="menuitem"
       style="padding-left: 24px;"
       tabindex="-1"
-      title="submenu"
     >
-      submenu
-      <i
-        class="rc-menu-submenu-arrow"
-      />
-    </div>
-  </li>
-</ul>
+      3
+    </li>
+    <li
+      class="rc-menu-item-group"
+    >
+      <div
+        class="rc-menu-item-group-title"
+        title="g2"
+      >
+        g2
+      </div>
+      <ul
+        class="rc-menu-item-group-list"
+      >
+        <li
+          class="rc-menu-item"
+          data-menu-id="rc-menu-uuid-test-4"
+          role="menuitem"
+          style="padding-left: 24px;"
+          tabindex="-1"
+        >
+          4
+        </li>
+        <li
+          aria-disabled="true"
+          class="rc-menu-item rc-menu-item-disabled"
+          data-menu-id="rc-menu-uuid-test-5"
+          role="menuitem"
+          style="padding-left: 24px;"
+        >
+          5
+        </li>
+      </ul>
+    </li>
+    <li
+      class="rc-menu-submenu rc-menu-submenu-inline"
+      role="none"
+    >
+      <div
+        aria-controls="rc-menu-uuid-test-tmp_key-3-popup"
+        aria-expanded="false"
+        aria-haspopup="true"
+        class="rc-menu-submenu-title"
+        data-menu-id="rc-menu-uuid-test-tmp_key-3"
+        role="menuitem"
+        style="padding-left: 24px;"
+        tabindex="-1"
+        title="submenu"
+      >
+        submenu
+        <i
+          class="rc-menu-submenu-arrow"
+        />
+      </div>
+    </li>
+  </ul>,
+  <div
+    aria-hidden="true"
+    style="display: none;"
+  />,
+]
 `;
 
 exports[`Menu should render inline menu with rtl direction correctly 1`] = `
-<ul
-  class="rc-menu rc-menu-root rc-menu-inline myMenu rc-menu-rtl"
-  data-menu-list="true"
-  dir="rtl"
-  role="menu"
-  tabindex="0"
->
-  <li
-    class="rc-menu-item-group"
+Array [
+  <ul
+    class="rc-menu rc-menu-root rc-menu-inline myMenu rc-menu-rtl"
+    data-menu-list="true"
+    dir="rtl"
+    role="menu"
+    tabindex="0"
   >
-    <div
-      class="rc-menu-item-group-title"
-      title="g1"
+    <li
+      class="rc-menu-item-group"
     >
-      g1
-    </div>
-    <ul
-      class="rc-menu-item-group-list"
-    >
-      <li
-        class="rc-menu-item"
-        data-menu-id="rc-menu-uuid-test-1"
-        role="menuitem"
-        style="padding-right: 24px;"
-        tabindex="-1"
+      <div
+        class="rc-menu-item-group-title"
+        title="g1"
       >
-        1
-      </li>
-      <li
-        class="rc-menu-item-divider"
-      />
-      <li
-        class="rc-menu-item"
-        data-menu-id="rc-menu-uuid-test-2"
-        role="menuitem"
-        style="padding-right: 24px;"
-        tabindex="-1"
+        g1
+      </div>
+      <ul
+        class="rc-menu-item-group-list"
       >
-        2
-      </li>
-    </ul>
-  </li>
-  <li
-    class="rc-menu-item"
-    data-menu-id="rc-menu-uuid-test-3"
-    role="menuitem"
-    style="padding-right: 24px;"
-    tabindex="-1"
-  >
-    3
-  </li>
-  <li
-    class="rc-menu-item-group"
-  >
-    <div
-      class="rc-menu-item-group-title"
-      title="g2"
-    >
-      g2
-    </div>
-    <ul
-      class="rc-menu-item-group-list"
-    >
-      <li
-        class="rc-menu-item"
-        data-menu-id="rc-menu-uuid-test-4"
-        role="menuitem"
-        style="padding-right: 24px;"
-        tabindex="-1"
-      >
-        4
-      </li>
-      <li
-        aria-disabled="true"
-        class="rc-menu-item rc-menu-item-disabled"
-        data-menu-id="rc-menu-uuid-test-5"
-        role="menuitem"
-        style="padding-right: 24px;"
-      >
-        5
-      </li>
-    </ul>
-  </li>
-  <li
-    class="rc-menu-submenu rc-menu-submenu-inline"
-    role="none"
-  >
-    <div
-      aria-controls="rc-menu-uuid-test-tmp_key-3-popup"
-      aria-expanded="false"
-      aria-haspopup="true"
-      class="rc-menu-submenu-title"
-      data-menu-id="rc-menu-uuid-test-tmp_key-3"
+        <li
+          class="rc-menu-item"
+          data-menu-id="rc-menu-uuid-test-1"
+          role="menuitem"
+          style="padding-right: 24px;"
+          tabindex="-1"
+        >
+          1
+        </li>
+        <li
+          class="rc-menu-item-divider"
+        />
+        <li
+          class="rc-menu-item"
+          data-menu-id="rc-menu-uuid-test-2"
+          role="menuitem"
+          style="padding-right: 24px;"
+          tabindex="-1"
+        >
+          2
+        </li>
+      </ul>
+    </li>
+    <li
+      class="rc-menu-item"
+      data-menu-id="rc-menu-uuid-test-3"
       role="menuitem"
       style="padding-right: 24px;"
       tabindex="-1"
-      title="submenu"
     >
-      submenu
-      <i
-        class="rc-menu-submenu-arrow"
-      />
-    </div>
-  </li>
-</ul>
+      3
+    </li>
+    <li
+      class="rc-menu-item-group"
+    >
+      <div
+        class="rc-menu-item-group-title"
+        title="g2"
+      >
+        g2
+      </div>
+      <ul
+        class="rc-menu-item-group-list"
+      >
+        <li
+          class="rc-menu-item"
+          data-menu-id="rc-menu-uuid-test-4"
+          role="menuitem"
+          style="padding-right: 24px;"
+          tabindex="-1"
+        >
+          4
+        </li>
+        <li
+          aria-disabled="true"
+          class="rc-menu-item rc-menu-item-disabled"
+          data-menu-id="rc-menu-uuid-test-5"
+          role="menuitem"
+          style="padding-right: 24px;"
+        >
+          5
+        </li>
+      </ul>
+    </li>
+    <li
+      class="rc-menu-submenu rc-menu-submenu-inline"
+      role="none"
+    >
+      <div
+        aria-controls="rc-menu-uuid-test-tmp_key-3-popup"
+        aria-expanded="false"
+        aria-haspopup="true"
+        class="rc-menu-submenu-title"
+        data-menu-id="rc-menu-uuid-test-tmp_key-3"
+        role="menuitem"
+        style="padding-right: 24px;"
+        tabindex="-1"
+        title="submenu"
+      >
+        submenu
+        <i
+          class="rc-menu-submenu-arrow"
+        />
+      </div>
+    </li>
+  </ul>,
+  <div
+    aria-hidden="true"
+    style="display: none;"
+  />,
+]
 `;
 
 exports[`Menu should render should support Fragment 1`] = `
-<ul
-  class="rc-menu rc-menu-root rc-menu-vertical"
-  data-menu-list="true"
-  role="menu"
-  tabindex="0"
->
-  <li
-    class="rc-menu-submenu rc-menu-submenu-vertical"
-    role="none"
+Array [
+  <ul
+    class="rc-menu rc-menu-root rc-menu-vertical"
+    data-menu-list="true"
+    role="menu"
+    tabindex="0"
   >
-    <div
-      aria-controls="rc-menu-uuid-test-tmp_key-0-popup"
-      aria-expanded="false"
-      aria-haspopup="true"
-      class="rc-menu-submenu-title"
-      data-menu-id="rc-menu-uuid-test-tmp_key-0"
+    <li
+      class="rc-menu-submenu rc-menu-submenu-vertical"
+      role="none"
+    >
+      <div
+        aria-controls="rc-menu-uuid-test-tmp_key-0-popup"
+        aria-expanded="false"
+        aria-haspopup="true"
+        class="rc-menu-submenu-title"
+        data-menu-id="rc-menu-uuid-test-tmp_key-0"
+        role="menuitem"
+        tabindex="-1"
+        title="submenu"
+      >
+        submenu
+        <i
+          class="rc-menu-submenu-arrow"
+        />
+      </div>
+    </li>
+    <li
+      class="rc-menu-item"
+      data-menu-id="rc-menu-uuid-test-7"
       role="menuitem"
       tabindex="-1"
-      title="submenu"
     >
-      submenu
-      <i
-        class="rc-menu-submenu-arrow"
-      />
-    </div>
-  </li>
-  <li
-    class="rc-menu-item"
-    data-menu-id="rc-menu-uuid-test-7"
-    role="menuitem"
-    tabindex="-1"
-  >
-    6
-  </li>
-  <li
-    class="rc-menu-submenu rc-menu-submenu-vertical"
-    role="none"
-  >
-    <div
-      aria-controls="rc-menu-uuid-test-tmp_key-2-popup"
-      aria-expanded="false"
-      aria-haspopup="true"
-      class="rc-menu-submenu-title"
-      data-menu-id="rc-menu-uuid-test-tmp_key-2"
+      6
+    </li>
+    <li
+      class="rc-menu-submenu rc-menu-submenu-vertical"
+      role="none"
+    >
+      <div
+        aria-controls="rc-menu-uuid-test-tmp_key-2-popup"
+        aria-expanded="false"
+        aria-haspopup="true"
+        class="rc-menu-submenu-title"
+        data-menu-id="rc-menu-uuid-test-tmp_key-2"
+        role="menuitem"
+        tabindex="-1"
+        title="submenu"
+      >
+        submenu
+        <i
+          class="rc-menu-submenu-arrow"
+        />
+      </div>
+    </li>
+    <li
+      class="rc-menu-item"
+      data-menu-id="rc-menu-uuid-test-9"
       role="menuitem"
       tabindex="-1"
-      title="submenu"
     >
-      submenu
-      <i
-        class="rc-menu-submenu-arrow"
-      />
-    </div>
-  </li>
-  <li
-    class="rc-menu-item"
-    data-menu-id="rc-menu-uuid-test-9"
-    role="menuitem"
-    tabindex="-1"
-  >
-    6
-  </li>
-</ul>
+      6
+    </li>
+  </ul>,
+  <div
+    aria-hidden="true"
+    style="display: none;"
+  />,
+]
 `;
 
 exports[`Menu should render vertical menu correctly 1`] = `
-<ul
-  class="rc-menu rc-menu-root rc-menu-vertical myMenu"
-  data-menu-list="true"
-  role="menu"
-  tabindex="0"
->
-  <li
-    class="rc-menu-item-group"
+Array [
+  <ul
+    class="rc-menu rc-menu-root rc-menu-vertical myMenu"
+    data-menu-list="true"
+    role="menu"
+    tabindex="0"
   >
-    <div
-      class="rc-menu-item-group-title"
-      title="g1"
+    <li
+      class="rc-menu-item-group"
     >
-      g1
-    </div>
-    <ul
-      class="rc-menu-item-group-list"
-    >
-      <li
-        class="rc-menu-item"
-        data-menu-id="rc-menu-uuid-test-1"
-        role="menuitem"
-        tabindex="-1"
+      <div
+        class="rc-menu-item-group-title"
+        title="g1"
       >
-        1
-      </li>
-      <li
-        class="rc-menu-item-divider"
-      />
-      <li
-        class="rc-menu-item"
-        data-menu-id="rc-menu-uuid-test-2"
-        role="menuitem"
-        tabindex="-1"
+        g1
+      </div>
+      <ul
+        class="rc-menu-item-group-list"
       >
-        2
-      </li>
-    </ul>
-  </li>
-  <li
-    class="rc-menu-item"
-    data-menu-id="rc-menu-uuid-test-3"
-    role="menuitem"
-    tabindex="-1"
-  >
-    3
-  </li>
-  <li
-    class="rc-menu-item-group"
-  >
-    <div
-      class="rc-menu-item-group-title"
-      title="g2"
-    >
-      g2
-    </div>
-    <ul
-      class="rc-menu-item-group-list"
-    >
-      <li
-        class="rc-menu-item"
-        data-menu-id="rc-menu-uuid-test-4"
-        role="menuitem"
-        tabindex="-1"
-      >
-        4
-      </li>
-      <li
-        aria-disabled="true"
-        class="rc-menu-item rc-menu-item-disabled"
-        data-menu-id="rc-menu-uuid-test-5"
-        role="menuitem"
-      >
-        5
-      </li>
-    </ul>
-  </li>
-  <li
-    class="rc-menu-submenu rc-menu-submenu-vertical"
-    role="none"
-  >
-    <div
-      aria-controls="rc-menu-uuid-test-tmp_key-3-popup"
-      aria-expanded="false"
-      aria-haspopup="true"
-      class="rc-menu-submenu-title"
-      data-menu-id="rc-menu-uuid-test-tmp_key-3"
+        <li
+          class="rc-menu-item"
+          data-menu-id="rc-menu-uuid-test-1"
+          role="menuitem"
+          tabindex="-1"
+        >
+          1
+        </li>
+        <li
+          class="rc-menu-item-divider"
+        />
+        <li
+          class="rc-menu-item"
+          data-menu-id="rc-menu-uuid-test-2"
+          role="menuitem"
+          tabindex="-1"
+        >
+          2
+        </li>
+      </ul>
+    </li>
+    <li
+      class="rc-menu-item"
+      data-menu-id="rc-menu-uuid-test-3"
       role="menuitem"
       tabindex="-1"
-      title="submenu"
     >
-      submenu
-      <i
-        class="rc-menu-submenu-arrow"
-      />
-    </div>
-  </li>
-</ul>
+      3
+    </li>
+    <li
+      class="rc-menu-item-group"
+    >
+      <div
+        class="rc-menu-item-group-title"
+        title="g2"
+      >
+        g2
+      </div>
+      <ul
+        class="rc-menu-item-group-list"
+      >
+        <li
+          class="rc-menu-item"
+          data-menu-id="rc-menu-uuid-test-4"
+          role="menuitem"
+          tabindex="-1"
+        >
+          4
+        </li>
+        <li
+          aria-disabled="true"
+          class="rc-menu-item rc-menu-item-disabled"
+          data-menu-id="rc-menu-uuid-test-5"
+          role="menuitem"
+        >
+          5
+        </li>
+      </ul>
+    </li>
+    <li
+      class="rc-menu-submenu rc-menu-submenu-vertical"
+      role="none"
+    >
+      <div
+        aria-controls="rc-menu-uuid-test-tmp_key-3-popup"
+        aria-expanded="false"
+        aria-haspopup="true"
+        class="rc-menu-submenu-title"
+        data-menu-id="rc-menu-uuid-test-tmp_key-3"
+        role="menuitem"
+        tabindex="-1"
+        title="submenu"
+      >
+        submenu
+        <i
+          class="rc-menu-submenu-arrow"
+        />
+      </div>
+    </li>
+  </ul>,
+  <div
+    aria-hidden="true"
+    style="display: none;"
+  />,
+]
 `;
 
 exports[`Menu should render vertical menu with rtl direction correctly 1`] = `
-<ul
-  class="rc-menu rc-menu-root rc-menu-vertical myMenu rc-menu-rtl"
-  data-menu-list="true"
-  dir="rtl"
-  role="menu"
-  tabindex="0"
->
-  <li
-    class="rc-menu-item-group"
+Array [
+  <ul
+    class="rc-menu rc-menu-root rc-menu-vertical myMenu rc-menu-rtl"
+    data-menu-list="true"
+    dir="rtl"
+    role="menu"
+    tabindex="0"
   >
-    <div
-      class="rc-menu-item-group-title"
-      title="g1"
+    <li
+      class="rc-menu-item-group"
     >
-      g1
-    </div>
-    <ul
-      class="rc-menu-item-group-list"
-    >
-      <li
-        class="rc-menu-item"
-        data-menu-id="rc-menu-uuid-test-1"
-        role="menuitem"
-        tabindex="-1"
+      <div
+        class="rc-menu-item-group-title"
+        title="g1"
       >
-        1
-      </li>
-      <li
-        class="rc-menu-item-divider"
-      />
-      <li
-        class="rc-menu-item"
-        data-menu-id="rc-menu-uuid-test-2"
-        role="menuitem"
-        tabindex="-1"
+        g1
+      </div>
+      <ul
+        class="rc-menu-item-group-list"
       >
-        2
-      </li>
-    </ul>
-  </li>
-  <li
-    class="rc-menu-item"
-    data-menu-id="rc-menu-uuid-test-3"
-    role="menuitem"
-    tabindex="-1"
-  >
-    3
-  </li>
-  <li
-    class="rc-menu-item-group"
-  >
-    <div
-      class="rc-menu-item-group-title"
-      title="g2"
-    >
-      g2
-    </div>
-    <ul
-      class="rc-menu-item-group-list"
-    >
-      <li
-        class="rc-menu-item"
-        data-menu-id="rc-menu-uuid-test-4"
-        role="menuitem"
-        tabindex="-1"
-      >
-        4
-      </li>
-      <li
-        aria-disabled="true"
-        class="rc-menu-item rc-menu-item-disabled"
-        data-menu-id="rc-menu-uuid-test-5"
-        role="menuitem"
-      >
-        5
-      </li>
-    </ul>
-  </li>
-  <li
-    class="rc-menu-submenu rc-menu-submenu-vertical"
-    role="none"
-  >
-    <div
-      aria-controls="rc-menu-uuid-test-tmp_key-3-popup"
-      aria-expanded="false"
-      aria-haspopup="true"
-      class="rc-menu-submenu-title"
-      data-menu-id="rc-menu-uuid-test-tmp_key-3"
+        <li
+          class="rc-menu-item"
+          data-menu-id="rc-menu-uuid-test-1"
+          role="menuitem"
+          tabindex="-1"
+        >
+          1
+        </li>
+        <li
+          class="rc-menu-item-divider"
+        />
+        <li
+          class="rc-menu-item"
+          data-menu-id="rc-menu-uuid-test-2"
+          role="menuitem"
+          tabindex="-1"
+        >
+          2
+        </li>
+      </ul>
+    </li>
+    <li
+      class="rc-menu-item"
+      data-menu-id="rc-menu-uuid-test-3"
       role="menuitem"
       tabindex="-1"
-      title="submenu"
     >
-      submenu
-      <i
-        class="rc-menu-submenu-arrow"
-      />
-    </div>
-  </li>
-</ul>
+      3
+    </li>
+    <li
+      class="rc-menu-item-group"
+    >
+      <div
+        class="rc-menu-item-group-title"
+        title="g2"
+      >
+        g2
+      </div>
+      <ul
+        class="rc-menu-item-group-list"
+      >
+        <li
+          class="rc-menu-item"
+          data-menu-id="rc-menu-uuid-test-4"
+          role="menuitem"
+          tabindex="-1"
+        >
+          4
+        </li>
+        <li
+          aria-disabled="true"
+          class="rc-menu-item rc-menu-item-disabled"
+          data-menu-id="rc-menu-uuid-test-5"
+          role="menuitem"
+        >
+          5
+        </li>
+      </ul>
+    </li>
+    <li
+      class="rc-menu-submenu rc-menu-submenu-vertical"
+      role="none"
+    >
+      <div
+        aria-controls="rc-menu-uuid-test-tmp_key-3-popup"
+        aria-expanded="false"
+        aria-haspopup="true"
+        class="rc-menu-submenu-title"
+        data-menu-id="rc-menu-uuid-test-tmp_key-3"
+        role="menuitem"
+        tabindex="-1"
+        title="submenu"
+      >
+        submenu
+        <i
+          class="rc-menu-submenu-arrow"
+        />
+      </div>
+    </li>
+  </ul>,
+  <div
+    aria-hidden="true"
+    style="display: none;"
+  />,
+]
 `;

--- a/tests/__snapshots__/MenuItem.spec.js.snap
+++ b/tests/__snapshots__/MenuItem.spec.js.snap
@@ -46,89 +46,95 @@ exports[`MenuItem overwrite default role should set role to option 1`] = `
 `;
 
 exports[`MenuItem rest props onClick event should only trigger 1 time along the component hierarchy 1`] = `
-<ul
-  class="rc-menu rc-menu-root rc-menu-inline"
-  data-menu-list="true"
-  role="menu"
-  tabindex="0"
->
-  <li
-    class="rc-menu-item rc-menu-item-active className"
-    data-menu-id="rc-menu-uuid-test-1"
-    data-whatever="whatever"
-    role="menuitem"
-    style="padding-left: 24px; font-size: 20px;"
-    tabindex="-1"
-    title="title"
+Array [
+  <ul
+    class="rc-menu rc-menu-root rc-menu-inline"
+    data-menu-list="true"
+    role="menu"
+    tabindex="0"
   >
-    1
-  </li>
-  <li
-    class="rc-menu-submenu rc-menu-submenu-inline className rc-menu-submenu-open"
-    data-whatever="whatever"
-    role="none"
-    style="font-size: 20px;"
-  >
-    <div
-      aria-controls="rc-menu-uuid-test-bamboo-popup"
-      aria-expanded="true"
-      aria-haspopup="true"
-      class="rc-menu-submenu-title"
-      data-menu-id="rc-menu-uuid-test-bamboo"
+    <li
+      class="rc-menu-item rc-menu-item-active className"
+      data-menu-id="rc-menu-uuid-test-1"
+      data-whatever="whatever"
       role="menuitem"
-      style="padding-left: 24px;"
+      style="padding-left: 24px; font-size: 20px;"
       tabindex="-1"
       title="title"
     >
-      title
-      <i
-        class="rc-menu-submenu-arrow"
-      />
-    </div>
-    <ul
-      class="rc-menu rc-menu-sub rc-menu-inline"
-      data-menu-list="true"
-      id="rc-menu-uuid-test-bamboo-popup"
+      1
+    </li>
+    <li
+      class="rc-menu-submenu rc-menu-submenu-inline className rc-menu-submenu-open"
+      data-whatever="whatever"
+      role="none"
+      style="font-size: 20px;"
     >
-      <li
-        class="rc-menu-item className"
-        data-menu-id="rc-menu-uuid-test-2"
-        data-whatever="whatever"
+      <div
+        aria-controls="rc-menu-uuid-test-bamboo-popup"
+        aria-expanded="true"
+        aria-haspopup="true"
+        class="rc-menu-submenu-title"
+        data-menu-id="rc-menu-uuid-test-bamboo"
         role="menuitem"
-        style="padding-left: 48px; font-size: 20px;"
+        style="padding-left: 24px;"
         tabindex="-1"
         title="title"
       >
-        3
-      </li>
-    </ul>
-  </li>
-  <li
-    class="rc-menu-item-group className"
-    data-whatever="whatever"
-    style="font-size: 20px;"
-  >
-    <div
-      class="rc-menu-item-group-title"
-      title="title"
+        title
+        <i
+          class="rc-menu-submenu-arrow"
+        />
+      </div>
+      <ul
+        class="rc-menu rc-menu-sub rc-menu-inline"
+        data-menu-list="true"
+        id="rc-menu-uuid-test-bamboo-popup"
+      >
+        <li
+          class="rc-menu-item className"
+          data-menu-id="rc-menu-uuid-test-2"
+          data-whatever="whatever"
+          role="menuitem"
+          style="padding-left: 48px; font-size: 20px;"
+          tabindex="-1"
+          title="title"
+        >
+          3
+        </li>
+      </ul>
+    </li>
+    <li
+      class="rc-menu-item-group className"
+      data-whatever="whatever"
+      style="font-size: 20px;"
     >
-      title
-    </div>
-    <ul
-      class="rc-menu-item-group-list"
-    >
-      <li
-        class="rc-menu-item className"
-        data-menu-id="rc-menu-uuid-test-3"
-        data-whatever="whatever"
-        role="menuitem"
-        style="padding-left: 24px; font-size: 20px;"
-        tabindex="-1"
+      <div
+        class="rc-menu-item-group-title"
         title="title"
       >
-        4
-      </li>
-    </ul>
-  </li>
-</ul>
+        title
+      </div>
+      <ul
+        class="rc-menu-item-group-list"
+      >
+        <li
+          class="rc-menu-item className"
+          data-menu-id="rc-menu-uuid-test-3"
+          data-whatever="whatever"
+          role="menuitem"
+          style="padding-left: 24px; font-size: 20px;"
+          tabindex="-1"
+          title="title"
+        >
+          4
+        </li>
+      </ul>
+    </li>
+  </ul>,
+  <div
+    aria-hidden="true"
+    style="display: none;"
+  />,
+]
 `;

--- a/tests/__snapshots__/Responsive.spec.tsx.snap
+++ b/tests/__snapshots__/Responsive.spec.tsx.snap
@@ -62,6 +62,11 @@ Array [
       </div>
     </li>
   </ul>,
-  "Bamboo",
+  <div
+    aria-hidden="true"
+    style="display:none"
+  >
+    Bamboo
+  </div>,
 ]
 `;


### PR DESCRIPTION
Menu `keyPath` 居然是反过来的，史前巨坑呐。

ref https://github.com/ant-design/ant-design/issues/30733

ref https://github.com/react-component/menu/blame/1870b7943426f2357f74759b2e843707d94a3894/src/SubMenu.jsx#L289