### PR TITLE
fix: Collapsed inline menu whit Three level submenu bug

### DIFF
--- a/src/SubMenu/PopupTrigger.tsx
+++ b/src/SubMenu/PopupTrigger.tsx
@@ -104,6 +104,7 @@ export default function PopupTrigger({
       onPopupVisibleChange={onVisibleChange}
       forceRender={forceSubMenuRender}
       popupMotion={mergedMotion}
+      destroyPopupOnHide={true}
     >
       {children}
     </Trigger>


### PR DESCRIPTION
[ant-design issue](https://github.com/ant-design/ant-design/issues/30906)

### 官方文档可复现

 [https://ant.design/components/menu-cn/#components-menu-demo-inline-collapsed](https://ant.design/components/menu-cn/#components-menu-demo-inline-collapsed)

### Steps to reproduce

1. 缩起内嵌菜单
2. 点击三级菜单
3. 打开内嵌菜单
4. 点击三级标题，此时缩起状态的三级菜单异常浮现

![menu](https://user-images.githubusercontent.com/9513530/121482355-ae1e5900-c9ff-11eb-8c7e-92a821eb3f20.gif)

### After fixing the bug

![menu2](https://user-images.githubusercontent.com/9513530/121483023-4d435080-ca00-11eb-96d1-2136a1f7df40.gif)

