### PR TITLE
fix: input in menu can not move cursor by arrow keys

### DIFF
--- a/src/hooks/useAccessibility.ts
+++ b/src/hooks/useAccessibility.ts
@@ -263,8 +263,11 @@ export default function useAccessibility<T extends HTMLElement>(
         return;
       }
 
-      // Arrow prevent default to avoid page scroll
-      if (ArrowKeys.includes(which) || [HOME, END].includes(which)) {
+      // Arrow prevent default to avoid page scroll, not apply for input and textarea
+      if (
+        (ArrowKeys.includes(which) || [HOME, END].includes(which)) &&
+        !['INPUT', 'TEXTAREA'].includes(e.target.nodeType)
+      ) {
         e.preventDefault();
       }
 


### PR DESCRIPTION
Issue demo:
https://codesandbox.io/s/ji-ben-antd-4-18-5-forked-orrdd?file=/index.js

Have tried to add test case, but not success to simulate keyDown event（[official issue](https://github.com/enzymejs/enzyme/issues/441)）:
```ts
  it('input and textarea cursor can be moved by arrow', () => {
    const wrapper = mount(
      <input value='123' onFocus={e => e.target} />,
    );

    const input = wrapper.find('input');
    input.simulate('focus');
    const inputNode = input.getDOMNode();
    expect(inputNode.selectionStart).toEqual(0);
    input.simulate('keyDown', { which: KeyCode.A, keyCode: KeyCode.A });
    expect(inputNode.value).toEqual('123A');
    expect(inputNode.selectionStart).toEqual(1);
    input.simulate('keyDown', { which: KeyCode.LEFT });
    expect(inputNode.selectionStart).toEqual(0);

    const textarea = wrapper.find('textarea');
    textarea.simulate('click');
    expect(textarea.selectionStart).toEqual(0);
    wrapper.find('Overflow').simulate('keyDown', { which: KeyCode.RIGHT });
    expect(textarea.selectionStart).toEqual(1);
    wrapper.find('Overflow').simulate('keyDown', { which: KeyCode.LEFT });
    expect(textarea.selectionStart).toEqual(0);
  });
```