### PR TITLE
fix menu popuptrigger flicker

### DIFF
--- a/src/SubMenu/index.tsx
+++ b/src/SubMenu/index.tsx
@@ -262,8 +262,10 @@ const InternalSubMenu = (props: SubMenuProps) => {
 
   // Cache mode if it change to `inline` which do not have popup motion
   const triggerModeRef = React.useRef(mode);
-  if (mode !== 'inline') {
-    triggerModeRef.current = connectedPath.length > 1 ? 'vertical' : mode;
+  if (mode !== 'inline' && connectedPath.length > 1) {
+    triggerModeRef.current = 'vertical';
+  } else {
+    triggerModeRef.current = mode;
   }
 
   if (!overflowDisabled) {

--- a/tests/Collapsed.spec.js
+++ b/tests/Collapsed.spec.js
@@ -46,6 +46,59 @@ describe('Menu.Collapsed', () => {
       );
     });
 
+    it('should always follow submenu popup hidden when mode is switched', () => {
+      const genMenu = props => (
+        <Menu mode="vertical" {...props}>
+          <SubMenu key="1" title="submenu1">
+            <SubMenu key="1-1" title="submenu1-1">
+              <MenuItem key="Option-1">Option 1</MenuItem>
+            </SubMenu>
+          </SubMenu>
+        </Menu>
+      );
+
+      const { container, rerender } = render(genMenu());
+
+      // Hover submenu1
+      fireEvent.mouseEnter(
+        container.querySelectorAll('.rc-menu-submenu-title')[0],
+      );
+
+      act(() => {
+        jest.runAllTimers();
+      });
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      // Hover submenu1-1
+      fireEvent.mouseEnter(
+        container.querySelectorAll('.rc-menu-submenu-title')[1],
+      );
+
+      act(() => {
+        jest.runAllTimers();
+      });
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      rerender(genMenu({ mode: 'inline' }));
+
+      // Click submenu1
+      fireEvent.click(container.querySelectorAll('.rc-menu-submenu-title')[0]);
+      // Click submenu1-1
+      fireEvent.click(container.querySelectorAll('.rc-menu-submenu-title')[2]);
+
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      expect(container.querySelectorAll('.rc-menu-submenu')[3]).toHaveClass(
+        'rc-menu-submenu-hidden',
+      );
+    });
+
     it('should always follow openKeys when inlineCollapsed is switched', () => {
       const genMenu = props => (
         <Menu defaultOpenKeys={['1']} mode="inline" {...props}>


### PR DESCRIPTION
切换 inline mode 后菜单栏点击展开最深层会出现上个 mode 的弹窗
ant-design 相关 issues https://github.com/ant-design/ant-design/issues/36636

https://user-images.githubusercontent.com/38420763/180976679-112d962d-ab0f-4785-b250-5018f66ebeb6.mp4