### PR TITLE
feat: Ignore top level indent

### DIFF
--- a/src/hooks/useDirectionStyle.ts
+++ b/src/hooks/useDirectionStyle.ts
@@ -8,7 +8,7 @@ export default function useDirectionStyle(level: number): React.CSSProperties {
     return null;
   }
 
-  const len = level;
+  const len = Math.max(0, level - 1);
   return rtl
     ? { paddingRight: len * inlineIndent }
     : { paddingLeft: len * inlineIndent };

--- a/tests/__snapshots__/Keyboard.spec.tsx.snap
+++ b/tests/__snapshots__/Keyboard.spec.tsx.snap
@@ -19,7 +19,7 @@ HTMLCollection [
         class="rc-menu-submenu-title"
         data-menu-id="rc-menu-uuid-test-light"
         role="menuitem"
-        style="padding-left: 24px;"
+        style="padding-left: 0px;"
         tabindex="-1"
         title="Light"
       >
@@ -37,7 +37,7 @@ HTMLCollection [
           class="rc-menu-item"
           data-menu-id="rc-menu-uuid-test-bamboo"
           role="menuitem"
-          style="padding-left: 48px;"
+          style="padding-left: 24px;"
           tabindex="-1"
         >
           Bamboo

--- a/tests/__snapshots__/Menu.spec.js.snap
+++ b/tests/__snapshots__/Menu.spec.js.snap
@@ -282,7 +282,7 @@ HTMLCollection [
           class="rc-menu-item"
           data-menu-id="rc-menu-uuid-test-1"
           role="menuitem"
-          style="padding-left: 24px;"
+          style="padding-left: 0px;"
           tabindex="-1"
         >
           1
@@ -294,7 +294,7 @@ HTMLCollection [
           class="rc-menu-item"
           data-menu-id="rc-menu-uuid-test-2"
           role="menuitem"
-          style="padding-left: 24px;"
+          style="padding-left: 0px;"
           tabindex="-1"
         >
           2
@@ -305,7 +305,7 @@ HTMLCollection [
       class="rc-menu-item"
       data-menu-id="rc-menu-uuid-test-3"
       role="menuitem"
-      style="padding-left: 24px;"
+      style="padding-left: 0px;"
       tabindex="-1"
     >
       3
@@ -326,7 +326,7 @@ HTMLCollection [
           class="rc-menu-item"
           data-menu-id="rc-menu-uuid-test-4"
           role="menuitem"
-          style="padding-left: 24px;"
+          style="padding-left: 0px;"
           tabindex="-1"
         >
           4
@@ -336,7 +336,7 @@ HTMLCollection [
           class="rc-menu-item rc-menu-item-disabled"
           data-menu-id="rc-menu-uuid-test-5"
           role="menuitem"
-          style="padding-left: 24px;"
+          style="padding-left: 0px;"
         >
           5
         </li>
@@ -353,7 +353,7 @@ HTMLCollection [
         class="rc-menu-submenu-title"
         data-menu-id="rc-menu-uuid-test-tmp_key-3"
         role="menuitem"
-        style="padding-left: 24px;"
+        style="padding-left: 0px;"
         tabindex="-1"
         title="submenu"
       >
@@ -396,7 +396,7 @@ HTMLCollection [
           class="rc-menu-item"
           data-menu-id="rc-menu-uuid-test-1"
           role="menuitem"
-          style="padding-right: 24px;"
+          style="padding-right: 0px;"
           tabindex="-1"
         >
           1
@@ -408,7 +408,7 @@ HTMLCollection [
           class="rc-menu-item"
           data-menu-id="rc-menu-uuid-test-2"
           role="menuitem"
-          style="padding-right: 24px;"
+          style="padding-right: 0px;"
           tabindex="-1"
         >
           2
@@ -419,7 +419,7 @@ HTMLCollection [
       class="rc-menu-item"
       data-menu-id="rc-menu-uuid-test-3"
       role="menuitem"
-      style="padding-right: 24px;"
+      style="padding-right: 0px;"
       tabindex="-1"
     >
       3
@@ -440,7 +440,7 @@ HTMLCollection [
           class="rc-menu-item"
           data-menu-id="rc-menu-uuid-test-4"
           role="menuitem"
-          style="padding-right: 24px;"
+          style="padding-right: 0px;"
           tabindex="-1"
         >
           4
@@ -450,7 +450,7 @@ HTMLCollection [
           class="rc-menu-item rc-menu-item-disabled"
           data-menu-id="rc-menu-uuid-test-5"
           role="menuitem"
-          style="padding-right: 24px;"
+          style="padding-right: 0px;"
         >
           5
         </li>
@@ -467,7 +467,7 @@ HTMLCollection [
         class="rc-menu-submenu-title"
         data-menu-id="rc-menu-uuid-test-tmp_key-3"
         role="menuitem"
-        style="padding-right: 24px;"
+        style="padding-right: 0px;"
         tabindex="-1"
         title="submenu"
       >

--- a/tests/__snapshots__/MenuItem.spec.js.snap
+++ b/tests/__snapshots__/MenuItem.spec.js.snap
@@ -58,7 +58,7 @@ HTMLCollection [
       data-menu-id="rc-menu-uuid-test-1"
       data-whatever="whatever"
       role="menuitem"
-      style="padding-left: 24px; font-size: 20px;"
+      style="padding-left: 0px; font-size: 20px;"
       tabindex="-1"
       title="title"
     >
@@ -77,7 +77,7 @@ HTMLCollection [
         class="rc-menu-submenu-title"
         data-menu-id="rc-menu-uuid-test-bamboo"
         role="menuitem"
-        style="padding-left: 24px;"
+        style="padding-left: 0px;"
         tabindex="-1"
         title="title"
       >
@@ -96,7 +96,7 @@ HTMLCollection [
           data-menu-id="rc-menu-uuid-test-2"
           data-whatever="whatever"
           role="menuitem"
-          style="padding-left: 48px; font-size: 20px;"
+          style="padding-left: 24px; font-size: 20px;"
           tabindex="-1"
           title="title"
         >
@@ -123,7 +123,7 @@ HTMLCollection [
           data-menu-id="rc-menu-uuid-test-3"
           data-whatever="whatever"
           role="menuitem"
-          style="padding-left: 24px; font-size: 20px;"
+          style="padding-left: 0px; font-size: 20px;"
           tabindex="-1"
           title="title"
         >

--- a/tests/__snapshots__/Options.spec.tsx.snap
+++ b/tests/__snapshots__/Options.spec.tsx.snap
@@ -19,7 +19,7 @@ HTMLCollection [
         class="rc-menu-submenu-title"
         data-menu-id="rc-menu-uuid-test-sub1"
         role="menuitem"
-        style="padding-left: 24px;"
+        style="padding-left: 0px;"
         tabindex="-1"
         title="SubMenu"
       >
@@ -49,7 +49,7 @@ HTMLCollection [
               class="rc-menu-item"
               data-menu-id="rc-menu-uuid-test-1"
               role="menuitem"
-              style="padding-left: 48px;"
+              style="padding-left: 24px;"
               tabindex="-1"
             >
               Menu Item 1
@@ -58,7 +58,7 @@ HTMLCollection [
               class="rc-menu-item"
               data-menu-id="rc-menu-uuid-test-2"
               role="menuitem"
-              style="padding-left: 48px;"
+              style="padding-left: 24px;"
               tabindex="-1"
             >
               Menu Item 2


### PR DESCRIPTION
现在 `inlineIndent` 设置后会造成菜单整体偏移，应该[忽略顶级菜单偏移](https://github.com/react-component/menu/issues/342)！

resolve https://github.com/ant-design/ant-design/issues/36811