### PR TITLE
fix: Submenu now properly hide when mouse exits

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -30,7 +30,8 @@
     direction: rtl;
   }
 
-  &-hidden {
+  &-hidden,
+  &-submenu-hidden {
     display: none;
   }
 


### PR DESCRIPTION
Fix #437 
May fix #422 

The cause is `rc-menu-submenu-hidden`'s style is not included in `index.css`, it should be `display: none`.

If this still does not fix the issue, manually add the style `display: none` for className `rc-menu-submenu-hidden`

---

P.S. Corresponding style is present in `menu.less` but I guess it's not compiled into `index.css` for some reason.