### PR TITLE
fix(a11y): ]  MenuItemGroup, SubMenuList add some role attributes for improved a11y

### DIFF
--- a/src/MenuItemGroup.tsx
+++ b/src/MenuItemGroup.tsx
@@ -32,17 +32,22 @@ const InternalMenuItemGroup = ({
 
   return (
     <li
+      role="presentation"
       {...restProps}
       onClick={e => e.stopPropagation()}
       className={classNames(groupPrefixCls, className)}
     >
       <div
+        role="presentation"
         className={`${groupPrefixCls}-title`}
         title={typeof title === 'string' ? title : undefined}
       >
         {title}
       </div>
-      <ul className={`${groupPrefixCls}-list`}>{children}</ul>
+      <ul
+        role="group"
+        className={`${groupPrefixCls}-list`}
+      >{children}</ul>
     </li>
   );
 };

--- a/src/MenuItemGroup.tsx
+++ b/src/MenuItemGroup.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
 import classNames from 'classnames';
 import omit from 'rc-util/lib/omit';
-import { parseChildren } from './utils/nodeUtil';
+import * as React from 'react';
 import { MenuContext } from './context/MenuContext';
 import { useFullPath, useMeasure } from './context/PathContext';
 import type { MenuItemGroupType } from './interface';
+import { parseChildren } from './utils/nodeUtil';
 
 export interface MenuItemGroupProps
   extends Omit<MenuItemGroupType, 'type' | 'children' | 'label'> {
@@ -44,10 +44,9 @@ const InternalMenuItemGroup = ({
       >
         {title}
       </div>
-      <ul
-        role="group"
-        className={`${groupPrefixCls}-list`}
-      >{children}</ul>
+      <ul role="group" className={`${groupPrefixCls}-list`}>
+        {children}
+      </ul>
     </li>
   );
 };
@@ -64,7 +63,7 @@ export default function MenuItemGroup({
 
   const measure = useMeasure();
   if (measure) {
-    return childList as any as React.ReactElement;
+    return (childList as any) as React.ReactElement;
   }
 
   return (

--- a/src/SubMenu/SubMenuList.tsx
+++ b/src/SubMenu/SubMenuList.tsx
@@ -22,10 +22,10 @@ const InternalSubMenuList = (
         `${prefixCls}-${mode === 'inline' ? 'inline' : 'vertical'}`,
         className,
       )}
+      role="menu"
       {...restProps}
       data-menu-list
       ref={ref}
-      role="menu"
     >
       {children}
     </ul>

--- a/src/SubMenu/SubMenuList.tsx
+++ b/src/SubMenu/SubMenuList.tsx
@@ -25,6 +25,7 @@ const InternalSubMenuList = (
       {...restProps}
       data-menu-list
       ref={ref}
+      role="menu"
     >
       {children}
     </ul>

--- a/tests/__snapshots__/Keyboard.spec.tsx.snap
+++ b/tests/__snapshots__/Keyboard.spec.tsx.snap
@@ -32,6 +32,7 @@ HTMLCollection [
         class="rc-menu rc-menu-sub rc-menu-inline"
         data-menu-list="true"
         id="rc-menu-uuid-test-light-popup"
+        role="menu"
       >
         <li
           class="rc-menu-item"

--- a/tests/__snapshots__/Menu.spec.js.snap
+++ b/tests/__snapshots__/Menu.spec.js.snap
@@ -53,15 +53,18 @@ HTMLCollection [
   >
     <li
       class="rc-menu-item-group"
+      role="presentation"
     >
       <div
         class="rc-menu-item-group-title"
+        role="presentation"
         title="g1"
       >
         g1
       </div>
       <ul
         class="rc-menu-item-group-list"
+        role="group"
       >
         <li
           class="rc-menu-item"
@@ -94,15 +97,18 @@ HTMLCollection [
     </li>
     <li
       class="rc-menu-item-group"
+      role="presentation"
     >
       <div
         class="rc-menu-item-group-title"
+        role="presentation"
         title="g2"
       >
         g2
       </div>
       <ul
         class="rc-menu-item-group-list"
+        role="group"
       >
         <li
           class="rc-menu-item"
@@ -161,15 +167,18 @@ HTMLCollection [
   >
     <li
       class="rc-menu-item-group"
+      role="presentation"
     >
       <div
         class="rc-menu-item-group-title"
+        role="presentation"
         title="g1"
       >
         g1
       </div>
       <ul
         class="rc-menu-item-group-list"
+        role="group"
       >
         <li
           class="rc-menu-item"
@@ -202,15 +211,18 @@ HTMLCollection [
     </li>
     <li
       class="rc-menu-item-group"
+      role="presentation"
     >
       <div
         class="rc-menu-item-group-title"
+        role="presentation"
         title="g2"
       >
         g2
       </div>
       <ul
         class="rc-menu-item-group-list"
+        role="group"
       >
         <li
           class="rc-menu-item"
@@ -268,15 +280,18 @@ HTMLCollection [
   >
     <li
       class="rc-menu-item-group"
+      role="presentation"
     >
       <div
         class="rc-menu-item-group-title"
+        role="presentation"
         title="g1"
       >
         g1
       </div>
       <ul
         class="rc-menu-item-group-list"
+        role="group"
       >
         <li
           class="rc-menu-item"
@@ -312,15 +327,18 @@ HTMLCollection [
     </li>
     <li
       class="rc-menu-item-group"
+      role="presentation"
     >
       <div
         class="rc-menu-item-group-title"
+        role="presentation"
         title="g2"
       >
         g2
       </div>
       <ul
         class="rc-menu-item-group-list"
+        role="group"
       >
         <li
           class="rc-menu-item"
@@ -382,15 +400,18 @@ HTMLCollection [
   >
     <li
       class="rc-menu-item-group"
+      role="presentation"
     >
       <div
         class="rc-menu-item-group-title"
+        role="presentation"
         title="g1"
       >
         g1
       </div>
       <ul
         class="rc-menu-item-group-list"
+        role="group"
       >
         <li
           class="rc-menu-item"
@@ -426,15 +447,18 @@ HTMLCollection [
     </li>
     <li
       class="rc-menu-item-group"
+      role="presentation"
     >
       <div
         class="rc-menu-item-group-title"
+        role="presentation"
         title="g2"
       >
         g2
       </div>
       <ul
         class="rc-menu-item-group-list"
+        role="group"
       >
         <li
           class="rc-menu-item"
@@ -567,15 +591,18 @@ HTMLCollection [
   >
     <li
       class="rc-menu-item-group"
+      role="presentation"
     >
       <div
         class="rc-menu-item-group-title"
+        role="presentation"
         title="g1"
       >
         g1
       </div>
       <ul
         class="rc-menu-item-group-list"
+        role="group"
       >
         <li
           class="rc-menu-item"
@@ -608,15 +635,18 @@ HTMLCollection [
     </li>
     <li
       class="rc-menu-item-group"
+      role="presentation"
     >
       <div
         class="rc-menu-item-group-title"
+        role="presentation"
         title="g2"
       >
         g2
       </div>
       <ul
         class="rc-menu-item-group-list"
+        role="group"
       >
         <li
           class="rc-menu-item"
@@ -675,15 +705,18 @@ HTMLCollection [
   >
     <li
       class="rc-menu-item-group"
+      role="presentation"
     >
       <div
         class="rc-menu-item-group-title"
+        role="presentation"
         title="g1"
       >
         g1
       </div>
       <ul
         class="rc-menu-item-group-list"
+        role="group"
       >
         <li
           class="rc-menu-item"
@@ -716,15 +749,18 @@ HTMLCollection [
     </li>
     <li
       class="rc-menu-item-group"
+      role="presentation"
     >
       <div
         class="rc-menu-item-group-title"
+        role="presentation"
         title="g2"
       >
         g2
       </div>
       <ul
         class="rc-menu-item-group-list"
+        role="group"
       >
         <li
           class="rc-menu-item"

--- a/tests/__snapshots__/MenuItem.spec.js.snap
+++ b/tests/__snapshots__/MenuItem.spec.js.snap
@@ -107,16 +107,19 @@ HTMLCollection [
     <li
       class="rc-menu-item-group className"
       data-whatever="whatever"
+      role="presentation"
       style="font-size: 20px;"
     >
       <div
         class="rc-menu-item-group-title"
+        role="presentation"
         title="title"
       >
         title
       </div>
       <ul
         class="rc-menu-item-group-list"
+        role="group"
       >
         <li
           class="rc-menu-item className"

--- a/tests/__snapshots__/MenuItem.spec.js.snap
+++ b/tests/__snapshots__/MenuItem.spec.js.snap
@@ -90,6 +90,7 @@ HTMLCollection [
         class="rc-menu rc-menu-sub rc-menu-inline"
         data-menu-list="true"
         id="rc-menu-uuid-test-bamboo-popup"
+        role="menu"
       >
         <li
           class="rc-menu-item className"

--- a/tests/__snapshots__/Options.spec.tsx.snap
+++ b/tests/__snapshots__/Options.spec.tsx.snap
@@ -32,6 +32,7 @@ HTMLCollection [
         class="rc-menu rc-menu-sub rc-menu-inline"
         data-menu-list="true"
         id="rc-menu-uuid-test-sub1-popup"
+        role="menu"
       >
         <li
           class="rc-menu-item-group"

--- a/tests/__snapshots__/Options.spec.tsx.snap
+++ b/tests/__snapshots__/Options.spec.tsx.snap
@@ -35,15 +35,18 @@ HTMLCollection [
       >
         <li
           class="rc-menu-item-group"
+          role="presentation"
         >
           <div
             class="rc-menu-item-group-title"
+            role="presentation"
             title="Menu Group"
           >
             Menu Group
           </div>
           <ul
             class="rc-menu-item-group-list"
+            role="group"
           >
             <li
               class="rc-menu-item"

--- a/tests/__snapshots__/SubMenu.spec.js.snap
+++ b/tests/__snapshots__/SubMenu.spec.js.snap
@@ -90,6 +90,7 @@ HTMLCollection [
             class="rc-menu rc-menu-sub rc-menu-vertical"
             data-menu-list="true"
             id="rc-menu-uuid-test-1-popup"
+            role="menu"
           >
             <li
               aria-selected="false"


### PR DESCRIPTION
### Description
Using the axe a11y chrome plugin - some a11y concerns are surfaced. 

Basically when using `role="menu"` the dom hierarchy is very specific.  If additional elements exist between what's expected, they should have `role="presentation` or `role="none"` so screen readers know to ignore them.

**Before**
<img width="1275" alt="before-fix" src="https://user-images.githubusercontent.com/196369/207932474-5db03fa6-4e46-403c-9952-10806d38b9c1.png">

**After**

<img width="1266" alt="fixed" src="https://user-images.githubusercontent.com/196369/207932550-35d142f6-7593-4b25-9c24-4b3db3123ec3.png">
