### PR TITLE
fix: vertical animation not being affected by inline

### DIFF
--- a/src/SubMenu/PopupTrigger.tsx
+++ b/src/SubMenu/PopupTrigger.tsx
@@ -62,20 +62,18 @@ export default function PopupTrigger({
   const popupPlacement = popupPlacementMap[mode];
 
   const targetMotion = getMotion(mode, motion, defaultMotions);
-  const [innerMotion, setInnerMotion] = React.useState(targetMotion);
+  const targetMotionRef = React.useRef(targetMotion);
 
-  React.useEffect(() => {
+  if (mode !== 'inline') {
     /**
      * PopupTrigger is only used for vertical and horizontal types.
      * When collapsed is unfolded, the inline animation will destroy the vertical animation.
      */
-    if (mode !== 'inline') {
-      setInnerMotion(targetMotion);
-    }
-  }, [mode, motion, defaultMotions]);
+    targetMotionRef.current = targetMotion;
+  }
 
   const mergedMotion: CSSMotionProps = {
-    ...innerMotion,
+    ...targetMotionRef.current,
     leavedClassName: `${prefixCls}-hidden`,
     removeOnLeave: false,
     motionAppear: true,

--- a/src/SubMenu/PopupTrigger.tsx
+++ b/src/SubMenu/PopupTrigger.tsx
@@ -62,9 +62,20 @@ export default function PopupTrigger({
   const popupPlacement = popupPlacementMap[mode];
 
   const targetMotion = getMotion(mode, motion, defaultMotions);
+  const [innerMotion, setInnerMotion] = React.useState(targetMotion);
+
+  React.useEffect(() => {
+    /**
+     * PopupTrigger is only used for vertical and horizontal types.
+     * When collapsed is unfolded, the inline animation will destroy the vertical animation.
+     */
+    if (mode !== 'inline') {
+      setInnerMotion(targetMotion);
+    }
+  }, [mode, motion, defaultMotions]);
 
   const mergedMotion: CSSMotionProps = {
-    ...targetMotion,
+    ...innerMotion,
     leavedClassName: `${prefixCls}-hidden`,
     removeOnLeave: false,
     motionAppear: true,

--- a/tests/Menu.spec.js
+++ b/tests/Menu.spec.js
@@ -574,6 +574,22 @@ describe('Menu', () => {
       rerender(genMenu({ mode: 'vertical' }));
       expect(global.triggerProps.popupMotion.motionName).toEqual('bambooLight');
     });
+
+    it('inline does not affect vertical motion', () => {
+      const genMenu = props => (
+        <Menu defaultMotions={defaultMotions} {...props}>
+          <SubMenu key="bamboo">
+            <MenuItem key="light" />
+          </SubMenu>
+        </Menu>
+      );
+
+      const { rerender } = render(genMenu({ mode: 'vertical' }));
+      rerender(genMenu({ mode: 'inline' }));
+      expect(global.triggerProps.popupMotion.motionName).toEqual(
+        'defaultMotion',
+      );
+    });
   });
 
   it('onMouseEnter should work', () => {


### PR DESCRIPTION
这是个祖传bug，一两年前就有这个问题
https://github.com/ant-design/ant-design/issues/39283

mode 为 vertical 和 horizontal 才需要用到 PopupTrigger，
快速切换时 inline 的 Motion 会影响到 vertical 的结束动画。
