### PR TITLE
fix: Resolve console error when MenuItem uses popupClassName

### DIFF
--- a/src/MenuItem.tsx
+++ b/src/MenuItem.tsx
@@ -38,8 +38,12 @@ export interface MenuItemProps
 class LegacyMenuItem extends React.Component<any> {
   render() {
     const { title, attribute, elementRef, ...restProps } = this.props;
-
-    const passedProps = omit(restProps, ['eventKey']);
+    
+    // Here the props are eventually passed to the DOM element.
+    // React does not recognize non-standard attributes.
+    // Therefore, remove the props that is not used here.
+    // ref: https://github.com/ant-design/ant-design/issues/41395
+    const passedProps = omit(restProps, ['eventKey', 'popupClassName', 'popupOffset', 'onTitleClick']);
     warning(
       !attribute,
       '`attribute` of Menu.Item is deprecated. Please pass attribute directly.',


### PR DESCRIPTION
fix: https://github.com/ant-design/ant-design/issues/41395

原因：由于在非 `SubMenu` 上使用了 `popupClassName` 属性，在整个过程中没有进行处理，最终该属性会被设置到 DOM 元素上去，但是 React 不识别 DOM 元素非标准的属性，因此出现报错。

解决方案：将  `popupClassName`  等一些未使用到的非标准的属性进行过滤。