### PR TITLE
fix: Menu.Item not support ref

### DIFF
--- a/src/MenuItem.tsx
+++ b/src/MenuItem.tsx
@@ -1,18 +1,19 @@
-import * as React from 'react';
 import classNames from 'classnames';
 import Overflow from 'rc-overflow';
-import warning from 'rc-util/lib/warning';
 import KeyCode from 'rc-util/lib/KeyCode';
 import omit from 'rc-util/lib/omit';
-import type { MenuInfo, MenuItemType } from './interface';
-import { MenuContext } from './context/MenuContext';
-import useActive from './hooks/useActive';
-import { warnItemProp } from './utils/warnUtil';
-import Icon from './Icon';
-import useDirectionStyle from './hooks/useDirectionStyle';
-import { useFullPath, useMeasure } from './context/PathContext';
+import { useComposeRef } from 'rc-util/lib/ref';
+import warning from 'rc-util/lib/warning';
+import * as React from 'react';
 import { useMenuId } from './context/IdContext';
+import { MenuContext } from './context/MenuContext';
+import { useFullPath, useMeasure } from './context/PathContext';
 import PrivateContext from './context/PrivateContext';
+import useActive from './hooks/useActive';
+import useDirectionStyle from './hooks/useDirectionStyle';
+import Icon from './Icon';
+import type { MenuInfo, MenuItemType } from './interface';
+import { warnItemProp } from './utils/warnUtil';
 
 export interface MenuItemProps
   extends Omit<MenuItemType, 'label' | 'key'>,
@@ -38,12 +39,17 @@ export interface MenuItemProps
 class LegacyMenuItem extends React.Component<any> {
   render() {
     const { title, attribute, elementRef, ...restProps } = this.props;
-    
+
     // Here the props are eventually passed to the DOM element.
     // React does not recognize non-standard attributes.
     // Therefore, remove the props that is not used here.
     // ref: https://github.com/ant-design/ant-design/issues/41395
-    const passedProps = omit(restProps, ['eventKey', 'popupClassName', 'popupOffset', 'onTitleClick']);
+    const passedProps = omit(restProps, [
+      'eventKey',
+      'popupClassName',
+      'popupOffset',
+      'onTitleClick',
+    ]);
     warning(
       !attribute,
       '`attribute` of Menu.Item is deprecated. Please pass attribute directly.',
@@ -63,184 +69,191 @@ class LegacyMenuItem extends React.Component<any> {
 /**
  * Real Menu Item component
  */
-const InternalMenuItem = (props: MenuItemProps) => {
-  const {
-    style,
-    className,
+const InternalMenuItem = React.forwardRef(
+  (props: MenuItemProps, ref: React.Ref<HTMLElement>) => {
+    const {
+      style,
+      className,
 
-    eventKey,
-    warnKey,
-    disabled,
-    itemIcon,
-    children,
+      eventKey,
+      warnKey,
+      disabled,
+      itemIcon,
+      children,
 
-    // Aria
-    role,
+      // Aria
+      role,
 
-    // Active
-    onMouseEnter,
-    onMouseLeave,
+      // Active
+      onMouseEnter,
+      onMouseLeave,
 
-    onClick,
-    onKeyDown,
+      onClick,
+      onKeyDown,
 
-    onFocus,
+      onFocus,
 
-    ...restProps
-  } = props;
+      ...restProps
+    } = props;
 
-  const domDataId = useMenuId(eventKey);
+    const domDataId = useMenuId(eventKey);
 
-  const {
-    prefixCls,
-    onItemClick,
+    const {
+      prefixCls,
+      onItemClick,
 
-    disabled: contextDisabled,
-    overflowDisabled,
+      disabled: contextDisabled,
+      overflowDisabled,
 
-    // Icon
-    itemIcon: contextItemIcon,
+      // Icon
+      itemIcon: contextItemIcon,
 
-    // Select
-    selectedKeys,
+      // Select
+      selectedKeys,
 
-    // Active
-    onActive,
-  } = React.useContext(MenuContext);
+      // Active
+      onActive,
+    } = React.useContext(MenuContext);
 
-  const { _internalRenderMenuItem } = React.useContext(PrivateContext);
+    const { _internalRenderMenuItem } = React.useContext(PrivateContext);
 
-  const itemCls = `${prefixCls}-item`;
+    const itemCls = `${prefixCls}-item`;
 
-  const legacyMenuItemRef = React.useRef<any>();
-  const elementRef = React.useRef<HTMLLIElement>();
-  const mergedDisabled = contextDisabled || disabled;
+    const legacyMenuItemRef = React.useRef<any>();
+    const elementRef = React.useRef<HTMLLIElement>();
+    const mergedDisabled = contextDisabled || disabled;
 
-  const connectedKeys = useFullPath(eventKey);
+    const mergedEleRef = useComposeRef(ref, elementRef);
 
-  // ================================ Warn ================================
-  if (process.env.NODE_ENV !== 'production' && warnKey) {
-    warning(false, 'MenuItem should not leave undefined `key`.');
-  }
+    const connectedKeys = useFullPath(eventKey);
 
-  // ============================= Info =============================
-  const getEventInfo = (
-    e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
-  ): MenuInfo => {
-    return {
-      key: eventKey,
-      // Note: For legacy code is reversed which not like other antd component
-      keyPath: [...connectedKeys].reverse(),
-      item: legacyMenuItemRef.current,
-      domEvent: e,
-    };
-  };
-
-  // ============================= Icon =============================
-  const mergedItemIcon = itemIcon || contextItemIcon;
-
-  // ============================ Active ============================
-  const { active, ...activeProps } = useActive(
-    eventKey,
-    mergedDisabled,
-    onMouseEnter,
-    onMouseLeave,
-  );
-
-  // ============================ Select ============================
-  const selected = selectedKeys.includes(eventKey);
-
-  // ======================== DirectionStyle ========================
-  const directionStyle = useDirectionStyle(connectedKeys.length);
-
-  // ============================ Events ============================
-  const onInternalClick: React.MouseEventHandler<HTMLLIElement> = e => {
-    if (mergedDisabled) {
-      return;
+    // ================================ Warn ================================
+    if (process.env.NODE_ENV !== 'production' && warnKey) {
+      warning(false, 'MenuItem should not leave undefined `key`.');
     }
 
-    const info = getEventInfo(e);
+    // ============================= Info =============================
+    const getEventInfo = (
+      e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
+    ): MenuInfo => {
+      return {
+        key: eventKey,
+        // Note: For legacy code is reversed which not like other antd component
+        keyPath: [...connectedKeys].reverse(),
+        item: legacyMenuItemRef.current,
+        domEvent: e,
+      };
+    };
 
-    onClick?.(warnItemProp(info));
-    onItemClick(info);
-  };
+    // ============================= Icon =============================
+    const mergedItemIcon = itemIcon || contextItemIcon;
 
-  const onInternalKeyDown: React.KeyboardEventHandler<HTMLLIElement> = e => {
-    onKeyDown?.(e);
+    // ============================ Active ============================
+    const { active, ...activeProps } = useActive(
+      eventKey,
+      mergedDisabled,
+      onMouseEnter,
+      onMouseLeave,
+    );
 
-    if (e.which === KeyCode.ENTER) {
+    // ============================ Select ============================
+    const selected = selectedKeys.includes(eventKey);
+
+    // ======================== DirectionStyle ========================
+    const directionStyle = useDirectionStyle(connectedKeys.length);
+
+    // ============================ Events ============================
+    const onInternalClick: React.MouseEventHandler<HTMLLIElement> = e => {
+      if (mergedDisabled) {
+        return;
+      }
+
       const info = getEventInfo(e);
 
-      // Legacy. Key will also trigger click event
       onClick?.(warnItemProp(info));
       onItemClick(info);
+    };
+
+    const onInternalKeyDown: React.KeyboardEventHandler<HTMLLIElement> = e => {
+      onKeyDown?.(e);
+
+      if (e.which === KeyCode.ENTER) {
+        const info = getEventInfo(e);
+
+        // Legacy. Key will also trigger click event
+        onClick?.(warnItemProp(info));
+        onItemClick(info);
+      }
+    };
+
+    /**
+     * Used for accessibility. Helper will focus element without key board.
+     * We should manually trigger an active
+     */
+    const onInternalFocus: React.FocusEventHandler<HTMLLIElement> = e => {
+      onActive(eventKey);
+      onFocus?.(e);
+    };
+
+    // ============================ Render ============================
+    const optionRoleProps: React.HTMLAttributes<HTMLDivElement> = {};
+
+    if (props.role === 'option') {
+      optionRoleProps['aria-selected'] = selected;
     }
-  };
 
-  /**
-   * Used for accessibility. Helper will focus element without key board.
-   * We should manually trigger an active
-   */
-  const onInternalFocus: React.FocusEventHandler<HTMLLIElement> = e => {
-    onActive(eventKey);
-    onFocus?.(e);
-  };
-
-  // ============================ Render ============================
-  const optionRoleProps: React.HTMLAttributes<HTMLDivElement> = {};
-
-  if (props.role === 'option') {
-    optionRoleProps['aria-selected'] = selected;
-  }
-
-  let renderNode = (
-    <LegacyMenuItem
-      ref={legacyMenuItemRef}
-      elementRef={elementRef}
-      role={role === null ? 'none' : role || 'menuitem'}
-      tabIndex={disabled ? null : -1}
-      data-menu-id={overflowDisabled && domDataId ? null : domDataId}
-      {...restProps}
-      {...activeProps}
-      {...optionRoleProps}
-      component="li"
-      aria-disabled={disabled}
-      style={{
-        ...directionStyle,
-        ...style,
-      }}
-      className={classNames(
-        itemCls,
-        {
-          [`${itemCls}-active`]: active,
-          [`${itemCls}-selected`]: selected,
-          [`${itemCls}-disabled`]: mergedDisabled,
-        },
-        className,
-      )}
-      onClick={onInternalClick}
-      onKeyDown={onInternalKeyDown}
-      onFocus={onInternalFocus}
-    >
-      {children}
-      <Icon
-        props={{
-          ...props,
-          isSelected: selected,
+    let renderNode = (
+      <LegacyMenuItem
+        ref={legacyMenuItemRef}
+        elementRef={mergedEleRef}
+        role={role === null ? 'none' : role || 'menuitem'}
+        tabIndex={disabled ? null : -1}
+        data-menu-id={overflowDisabled && domDataId ? null : domDataId}
+        {...restProps}
+        {...activeProps}
+        {...optionRoleProps}
+        component="li"
+        aria-disabled={disabled}
+        style={{
+          ...directionStyle,
+          ...style,
         }}
-        icon={mergedItemIcon}
-      />
-    </LegacyMenuItem>
-  );
+        className={classNames(
+          itemCls,
+          {
+            [`${itemCls}-active`]: active,
+            [`${itemCls}-selected`]: selected,
+            [`${itemCls}-disabled`]: mergedDisabled,
+          },
+          className,
+        )}
+        onClick={onInternalClick}
+        onKeyDown={onInternalKeyDown}
+        onFocus={onInternalFocus}
+      >
+        {children}
+        <Icon
+          props={{
+            ...props,
+            isSelected: selected,
+          }}
+          icon={mergedItemIcon}
+        />
+      </LegacyMenuItem>
+    );
 
-  if (_internalRenderMenuItem) {
-    renderNode = _internalRenderMenuItem(renderNode, props, { selected });
-  }
+    if (_internalRenderMenuItem) {
+      renderNode = _internalRenderMenuItem(renderNode, props, { selected });
+    }
 
-  return renderNode;
-};
+    return renderNode;
+  },
+);
 
-function MenuItem(props: MenuItemProps): React.ReactElement {
+function MenuItem(
+  props: MenuItemProps,
+  ref: React.Ref<HTMLElement>,
+): React.ReactElement {
   const { eventKey } = props;
 
   // ==================== Record KeyPath ====================
@@ -263,7 +276,7 @@ function MenuItem(props: MenuItemProps): React.ReactElement {
   }
 
   // ======================== Render ========================
-  return <InternalMenuItem {...props} />;
+  return <InternalMenuItem {...props} ref={ref} />;
 }
 
-export default MenuItem;
+export default React.forwardRef(MenuItem);

--- a/tests/React18.spec.tsx
+++ b/tests/React18.spec.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable no-undef */
-import React from 'react';
 import { act, render } from '@testing-library/react';
-import Menu, { MenuItem, SubMenu } from '../src';
+import React from 'react';
 import type { MenuProps } from '../src';
+import Menu, { MenuItem, SubMenu } from '../src';
 
 describe('React18', () => {
   function runAllTimer() {

--- a/tests/Responsive.spec.tsx
+++ b/tests/Responsive.spec.tsx
@@ -1,20 +1,22 @@
 /* eslint-disable no-undef, react/no-multi-comp, react/jsx-curly-brace-presence, max-classes-per-file */
 import { fireEvent, render } from '@testing-library/react';
+import ResizeObserver from 'rc-resize-observer';
 import KeyCode from 'rc-util/lib/KeyCode';
+import React from 'react';
 import { act } from 'react-dom/test-utils';
 import Menu, { MenuItem, SubMenu } from '../src';
 import { OVERFLOW_KEY } from '../src/hooks/useKeyRecords';
 import { last } from './util';
 
 jest.mock('rc-resize-observer', () => {
-  const React = require('react');
-  let ResizeObserver = jest.requireActual('rc-resize-observer');
-  ResizeObserver = ResizeObserver.default || ResizeObserver;
+  const R = require('react');
+  let RO = jest.requireActual('rc-resize-observer');
+  RO = RO.default || RO;
 
   let guid = 0;
 
-  return React.forwardRef((props, ref) => {
-    const [id] = React.useState(() => {
+  return R.forwardRef((props, ref) => {
+    const [id] = R.useState(() => {
       guid += 1;
       return guid;
     });
@@ -22,7 +24,7 @@ jest.mock('rc-resize-observer', () => {
     global.resizeProps = global.resizeProps || new Map<number, any>();
     global.resizeProps.set(id, props);
 
-    return React.createElement(ResizeObserver, { ref, ...props });
+    return R.createElement(RO, { ref, ...props });
   });
 });
 
@@ -39,6 +41,37 @@ describe('Menu.Responsive', () => {
   function getResizeProps(): any[] {
     return Array.from(global.resizeProps!.values());
   }
+
+  // MenuItem should support `ref` since HOC may use this
+  // https://github.com/ant-design/ant-design/issues/41570
+  it('StrictMode warning', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const MyItem = (props: any) => {
+      const domRef = React.useRef();
+
+      return (
+        <ResizeObserver onResize={() => {}} ref={domRef}>
+          <Menu.Item {...props} />
+        </ResizeObserver>
+      );
+    };
+
+    render(
+      <React.StrictMode>
+        <Menu mode="horizontal">
+          <MyItem key="1">Good</MyItem>
+        </Menu>
+      </React.StrictMode>,
+    );
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
 
   it('ssr render full', () => {
     const { container } = render(


### PR DESCRIPTION
As antd internal patch ref on Menu.Item. We need make it support ref. It's safe to remove after refactor.

fix https://github.com/ant-design/ant-design/issues/41570