### PR TITLE
feat: support a11y for menu divider

### DIFF
--- a/src/Divider.tsx
+++ b/src/Divider.tsx
@@ -16,6 +16,7 @@ export default function Divider({ className, style }: DividerProps) {
 
   return (
     <li
+      role="separator"
       className={classNames(`${prefixCls}-item-divider`, className)}
       style={style}
     />

--- a/tests/Menu.spec.tsx
+++ b/tests/Menu.spec.tsx
@@ -730,6 +730,7 @@ describe('Menu', () => {
 
     expect(document.activeElement).toBe(last(container.querySelectorAll('li')));
   });
+
   it('should render a divider with role="separator"', () => {
     const menuRef = React.createRef<MenuRef>();
     const { container } = render(

--- a/tests/Menu.spec.tsx
+++ b/tests/Menu.spec.tsx
@@ -730,5 +730,20 @@ describe('Menu', () => {
 
     expect(document.activeElement).toBe(last(container.querySelectorAll('li')));
   });
+  it('should render a divider with role="separator"', () => {
+    const menuRef = React.createRef<MenuRef>();
+    const { container } = render(
+      <Menu ref={menuRef} activeKey="cat">
+        <MenuItem key="light">Light</MenuItem>
+        <Divider />
+        <MenuItem key="cat">Cat</MenuItem>
+      </Menu>,
+    );
+    // Get the separator element
+    const separator = container.querySelector('[role="separator"]');
+
+    // Assert that the separator element with role="separator" exists
+    expect(separator).toBeInTheDocument();
+  });
 });
 /* eslint-enable */

--- a/tests/Menu.spec.tsx
+++ b/tests/Menu.spec.tsx
@@ -740,11 +740,11 @@ describe('Menu', () => {
         <MenuItem key="cat">Cat</MenuItem>
       </Menu>,
     );
-    // Get the separator element
-    const separator = container.querySelector('[role="separator"]');
+   // Get the divider element with the rc-menu-item-divider class
+   const divider = container.querySelector('.rc-menu-item-divider');
 
-    // Assert that the separator element with role="separator" exists
-    expect(separator).toBeInTheDocument();
+   // Assert that the divider element with rc-menu-item-divider class has role="separator"
+   expect(divider).toHaveAttribute('role', 'separator');
   });
 });
 /* eslint-enable */

--- a/tests/__snapshots__/Menu.spec.tsx.snap
+++ b/tests/__snapshots__/Menu.spec.tsx.snap
@@ -76,6 +76,7 @@ HTMLCollection [
         </li>
         <li
           class="rc-menu-item-divider"
+          role="separator"
         />
         <li
           class="rc-menu-item"
@@ -190,6 +191,7 @@ HTMLCollection [
         </li>
         <li
           class="rc-menu-item-divider"
+          role="separator"
         />
         <li
           class="rc-menu-item"
@@ -304,6 +306,7 @@ HTMLCollection [
         </li>
         <li
           class="rc-menu-item-divider"
+          role="separator"
         />
         <li
           class="rc-menu-item"
@@ -424,6 +427,7 @@ HTMLCollection [
         </li>
         <li
           class="rc-menu-item-divider"
+          role="separator"
         />
         <li
           class="rc-menu-item"
@@ -614,6 +618,7 @@ HTMLCollection [
         </li>
         <li
           class="rc-menu-item-divider"
+          role="separator"
         />
         <li
           class="rc-menu-item"
@@ -728,6 +733,7 @@ HTMLCollection [
         </li>
         <li
           class="rc-menu-item-divider"
+          role="separator"
         />
         <li
           class="rc-menu-item"

--- a/tests/__snapshots__/Options.spec.tsx.snap
+++ b/tests/__snapshots__/Options.spec.tsx.snap
@@ -73,6 +73,7 @@ HTMLCollection [
     </li>
     <li
       class="rc-menu-item-divider"
+      role="separator"
     />
   </ul>,
   <div


### PR DESCRIPTION
To help rc-menu comply to WCAG 2.1 better, current if scan the page with axe devtool we have this error on a11y:


<img width="617" alt="image" src="https://github.com/react-component/menu/assets/25930830/1234c6fd-c5ea-4ea4-b994-0cf3cdfdef0a">


I have decided to keep this role param fixed because this seem like the only approriate for the divider  
