### PR TITLE
fix: fix popup flicker issue when inline menus have benn collased

### DIFF
--- a/docs/examples/inlineCollapsed.tsx
+++ b/docs/examples/inlineCollapsed.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
 import Menu, { SubMenu, Item } from 'rc-menu';
 import './inlineCollapsed.less';
+import { inlineMotion } from './antd'
 
 const App = () => {
   const [collapsed, setCollapsed] = useState(false);
   return (
-    <>
+    <div style={{ height: 600 }}>
       <label>
         <input type="checkbox" value={collapsed} onChange={e => setCollapsed(e.target.checked)} />
         inlineCollapsed: {collapsed.toString()}
@@ -15,14 +16,19 @@ const App = () => {
         inlineCollapsed={collapsed}
         style={{ width: 600 }}
         className={collapsed ? 'collapsed' : ''}
+        motion={inlineMotion}
       >
         <Item key="1">item 1</Item>
         <SubMenu key="2" title={`inlineCollapsed: ${collapsed.toString()}`}>
           <Item key="3">item 2</Item>
           <Item key="4">item 3</Item>
+          <SubMenu key="5" title={`inlineCollapsed: ${collapsed.toString()}`} style={{ minWidth: 220 }}>
+            <Item key="6">item 4</Item>
+            <Item key="7">item 5</Item>
+          </SubMenu>
         </SubMenu>
       </Menu>
-    </>
+    </div>
   );
 }
 

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -599,6 +599,7 @@ const Menu = React.forwardRef<MenuRef, MenuProps>((props, ref) => {
           prefixCls={prefixCls}
           rootClassName={rootClassName}
           mode={internalMode}
+          inlineCollapsed={internalInlineCollapsed}
           openKeys={mergedOpenKeys}
           rtl={isRtl}
           // Disabled

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -598,6 +598,7 @@ const Menu = React.forwardRef<MenuRef, MenuProps>((props, ref) => {
         <MenuContextProvider
           prefixCls={prefixCls}
           rootClassName={rootClassName}
+          originMode={mode}
           mode={internalMode}
           inlineCollapsed={internalInlineCollapsed}
           openKeys={mergedOpenKeys}

--- a/src/SubMenu/PopupTrigger.tsx
+++ b/src/SubMenu/PopupTrigger.tsx
@@ -50,6 +50,7 @@ export default function PopupTrigger({
     forceSubMenuRender,
     rootClassName,
 
+    originMode,
     inlineCollapsed,
 
     // Motion
@@ -76,12 +77,13 @@ export default function PopupTrigger({
     targetMotionRef.current = targetMotion;
   }
 
-  const mergedMotion: CSSMotionProps = inlineCollapsed ? {
-    ...targetMotionRef.current,
-    leavedClassName: `${prefixCls}-hidden`,
-    removeOnLeave: false,
-    motionAppear: true,
-  } : undefined;
+  const mergedMotion: CSSMotionProps = originMode !== 'inline' || inlineCollapsed
+    ? {
+      ...targetMotionRef.current,
+      leavedClassName: `${prefixCls}-hidden`,
+      removeOnLeave: false,
+      motionAppear: true,
+    } : undefined;
 
   // Delay to change visible
   const visibleRef = React.useRef<number>();

--- a/src/SubMenu/PopupTrigger.tsx
+++ b/src/SubMenu/PopupTrigger.tsx
@@ -50,6 +50,8 @@ export default function PopupTrigger({
     forceSubMenuRender,
     rootClassName,
 
+    inlineCollapsed,
+
     // Motion
     motion,
     defaultMotions,
@@ -74,12 +76,12 @@ export default function PopupTrigger({
     targetMotionRef.current = targetMotion;
   }
 
-  const mergedMotion: CSSMotionProps = {
+  const mergedMotion: CSSMotionProps = inlineCollapsed ? {
     ...targetMotionRef.current,
     leavedClassName: `${prefixCls}-hidden`,
     removeOnLeave: false,
     motionAppear: true,
-  };
+  } : undefined;
 
   // Delay to change visible
   const visibleRef = React.useRef<number>();

--- a/src/context/MenuContext.tsx
+++ b/src/context/MenuContext.tsx
@@ -18,6 +18,7 @@ export interface MenuContextProps {
 
   // Mode
   mode: MenuMode;
+  inlineCollapsed?: boolean;
 
   // Disabled
   disabled?: boolean;

--- a/src/context/MenuContext.tsx
+++ b/src/context/MenuContext.tsx
@@ -17,6 +17,7 @@ export interface MenuContextProps {
   rtl?: boolean;
 
   // Mode
+  originMode: MenuMode;
   mode: MenuMode;
   inlineCollapsed?: boolean;
 


### PR DESCRIPTION
很久的一个历史问题了，antd 官方和本仓库demo都可复现。解析 Submenu 里的 items 时，如果存在嵌套 Submenu ，就出现此问题，即存在第三层 menu 的样式问题。

![Kapture 2023-09-26 at 11 02 42](https://github.com/react-component/menu/assets/20284707/837547d9-1242-4bf4-aeb8-63dbb2153e79)


解决方案：考虑在inline模式下非折叠时，不设置 motion 动画。

相关 issue ：https://github.com/ant-design/pro-components/issues/7607#issuecomment-1705497434，这个gif 同样问题。

相关 pr：
 1. https://github.com/react-component/menu/pull/410 ，这个pr是在折叠后，直接把 popup 内容销毁，同样可以实现。
 2. https://github.com/react-component/menu/pull/497 ，但是它是手动设置动画，依然解决不了上述问题。

