### PR TITLE
fix: opt out of ssr full to avoid initial flashing

### DIFF
--- a/docs/demo/ssr-off.md
+++ b/docs/demo/ssr-off.md
@@ -1,0 +1,3 @@
+## ssr off
+
+<code src="../examples/ssr-off.tsx"></code>

--- a/docs/examples/ssr-off.tsx
+++ b/docs/examples/ssr-off.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import '../../assets/index.less';
+import Menu, { Divider, Item as MenuItem, SubMenu } from '../../src';
+
+const nestSubMenu = (
+  <SubMenu
+    title={<span className="submenu-title-wrapper">offset sub menu 2</span>}
+    key="4"
+    popupOffset={[10, 15]}
+  >
+    <MenuItem key="4-1">inner inner</MenuItem>
+    <Divider />
+    <SubMenu
+      key="4-2"
+      title={<span className="submenu-title-wrapper">sub menu 1</span>}
+    >
+      <SubMenu
+        title={<span className="submenu-title-wrapper">sub 4-2-0</span>}
+        key="4-2-0"
+      >
+        <MenuItem key="4-2-0-1">inner inner</MenuItem>
+        <MenuItem key="4-2-0-2">inner inner2</MenuItem>
+      </SubMenu>
+      <MenuItem key="4-2-1">inn</MenuItem>
+      <SubMenu
+        title={<span className="submenu-title-wrapper">sub menu 4</span>}
+        key="4-2-2"
+      >
+        <MenuItem key="4-2-2-1">inner inner</MenuItem>
+        <MenuItem key="4-2-2-2">inner inner2</MenuItem>
+      </SubMenu>
+      <SubMenu
+        title={<span className="submenu-title-wrapper">sub menu 3</span>}
+        key="4-2-3"
+      >
+        <MenuItem key="4-2-3-1">inner inner</MenuItem>
+        <MenuItem key="4-2-3-2">inner inner2</MenuItem>
+      </SubMenu>
+    </SubMenu>
+  </SubMenu>
+);
+
+function handleClick(info) {
+  console.log(`clicked ${info.key}`);
+  console.log(info);
+}
+
+function Demo() {
+  return (
+    <>
+      <Menu mode="horizontal" onClick={handleClick} ssr="off">
+        <SubMenu
+          title={<span className="submenu-title-wrapper">sub menu</span>}
+          key="1"
+        >
+          <MenuItem key="1-1">0-1</MenuItem>
+          <MenuItem key="1-2">0-2</MenuItem>
+        </SubMenu>
+        {nestSubMenu}
+        <MenuItem key="2">1</MenuItem>
+        <MenuItem key="3">outer</MenuItem>
+        <MenuItem key="5" disabled>
+          disabled
+        </MenuItem>
+        <MenuItem key="6">outer3</MenuItem>
+      </Menu>
+    </>
+  );
+}
+
+export default Demo;

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -78,6 +78,9 @@ export interface MenuProps
   activeKey?: string;
   defaultActiveFirst?: boolean;
 
+  // SSR control
+  ssr?: 'full' | 'off';
+
   // Selection
   selectable?: boolean;
   multiple?: boolean;
@@ -183,6 +186,9 @@ const Menu = React.forwardRef<MenuRef, MenuProps>((props, ref) => {
     activeKey,
     defaultActiveFirst,
 
+    // SSR
+    ssr,
+
     // Selection
     selectable = true,
     multiple = false,
@@ -239,6 +245,7 @@ const Menu = React.forwardRef<MenuRef, MenuProps>((props, ref) => {
   const uuid = useUUID(id);
 
   const isRtl = direction === 'rtl';
+  const ssrVal = ssr === 'off' ? undefined : 'full';
 
   // ========================= Warn =========================
   if (process.env.NODE_ENV !== 'production') {
@@ -581,7 +588,7 @@ const Menu = React.forwardRef<MenuRef, MenuProps>((props, ref) => {
           ? Overflow.INVALIDATE
           : Overflow.RESPONSIVE
       }
-      ssr="full"
+      ssr={ssrVal}
       data-menu-list
       onVisibleChange={newLastIndex => {
         setLastVisibleIndex(newLastIndex);


### PR DESCRIPTION
**背景**: 
horizontal responsive模式下, 当全部 menu item 总宽度超出 overflow 宽度时, 默认全部 menu item 都会被绘制到页面, 出现溢出, 随后才会计算和隐藏. 

**期许**:
rc-menu 可能仅在 client 端使用, 这个时候, 希望ssr 值非写死, 实现 menu item 当被绘制时是已经计算好的数量, 不出现目前的闪动.

**复现方式**: 
可以用 antd menu 组件的第一个用例复现. 效果如下:

https://github.com/react-component/menu/assets/26617824/061f8e89-c2de-4366-8bb8-ad3b55322fa6



**代码改动简述**: 
在不变动 rc-menu 默认 ssr 设置 “full“ 的前提下, 加入新prop来支持跳出该默认设置.

