### PR TITLE
Fixed group and submenu initial focus

### DIFF
--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -11,11 +11,7 @@ import { IdContext } from './context/IdContext';
 import MenuContextProvider from './context/MenuContext';
 import { PathRegisterContext, PathUserContext } from './context/PathContext';
 import PrivateContext from './context/PrivateContext';
-import {
-  getFocusableElements,
-  refreshElements,
-  useAccessibility,
-} from './hooks/useAccessibility';
+import { refreshElements, useAccessibility } from './hooks/useAccessibility';
 import useKeyRecords, { OVERFLOW_KEY } from './hooks/useKeyRecords';
 import useMemoCallback from './hooks/useMemoCallback';
 import useUUID from './hooks/useUUID';
@@ -386,20 +382,22 @@ const Menu = React.forwardRef<MenuRef, MenuProps>((props, ref) => {
     return {
       list: containerRef.current,
       focus: options => {
+        let shouldFocusKey: string;
         const elements = new Set<HTMLElement>();
         const key2element = new Map<string, HTMLElement>();
         const element2key = new Map<HTMLElement, string>();
         const keys = getKeys();
 
         refreshElements(keys, uuid, elements, key2element, element2key);
+        if (mergedActiveKey) {
+          shouldFocusKey = mergedActiveKey;
+        } else {
+          const firstActiveElement = [...elements].find(
+            el => !el.ariaDisabled || el.ariaDisabled === 'false',
+          );
 
-        const focusableElements = getFocusableElements(
-          containerRef.current,
-          elements,
-        );
-
-        const shouldFocusKey =
-          mergedActiveKey ?? element2key.get(focusableElements[0]);
+          shouldFocusKey = element2key.get(firstActiveElement);
+        }
 
         const elementToFocus = key2element.get(shouldFocusKey);
 

--- a/src/hooks/useAccessibility.ts
+++ b/src/hooks/useAccessibility.ts
@@ -1,9 +1,9 @@
-import * as React from 'react';
+import { getFocusNodeList } from 'rc-util/lib/Dom/focus';
 import KeyCode from 'rc-util/lib/KeyCode';
 import raf from 'rc-util/lib/raf';
-import { getFocusNodeList } from 'rc-util/lib/Dom/focus';
-import type { MenuMode } from '../interface';
+import * as React from 'react';
 import { getMenuId } from '../context/IdContext';
+import type { MenuMode } from '../interface';
 
 // destruct to reduce minify size
 const { LEFT, RIGHT, UP, DOWN, ENTER, ESC, HOME, END } = KeyCode;
@@ -134,7 +134,7 @@ function getFocusElement(
 /**
  * Get focusable elements from the element set under provided container
  */
-function getFocusableElements(
+export function getFocusableElements(
   container: HTMLElement,
   elements: Set<HTMLElement>,
 ) {
@@ -181,7 +181,29 @@ function getNextFocusElement(
   return sameLevelFocusableMenuElementList[focusIndex];
 }
 
-export default function useAccessibility<T extends HTMLElement>(
+export const refreshElements = (
+  keys: string[],
+  id: string,
+  elements: Set<HTMLElement>,
+  key2element: Map<string, HTMLElement>,
+  element2key: Map<HTMLElement, string>,
+) => {
+  keys.forEach(key => {
+    const element = document.querySelector(
+      `[data-menu-id='${getMenuId(id, key)}']`,
+    ) as HTMLElement;
+
+    if (element) {
+      elements.add(element);
+      element2key.set(element, key);
+      key2element.set(key, element);
+    }
+  });
+
+  return elements;
+};
+
+export function useAccessibility<T extends HTMLElement>(
   mode: MenuMode,
   activeKey: string,
   isRtl: boolean,
@@ -216,35 +238,12 @@ export default function useAccessibility<T extends HTMLElement>(
     const { which } = e;
 
     if ([...ArrowKeys, ENTER, ESC, HOME, END].includes(which)) {
-      // Convert key to elements
-      let elements: Set<HTMLElement>;
-      let key2element: Map<string, HTMLElement>;
-      let element2key: Map<HTMLElement, string>;
+      const elements = new Set<HTMLElement>();
+      const key2element = new Map<string, HTMLElement>();
+      const element2key = new Map<HTMLElement, string>();
+      const keys = getKeys();
 
-      // >>> Wrap as function since we use raf for some case
-      const refreshElements = () => {
-        elements = new Set<HTMLElement>();
-        key2element = new Map();
-        element2key = new Map();
-
-        const keys = getKeys();
-
-        keys.forEach(key => {
-          const element = document.querySelector(
-            `[data-menu-id='${getMenuId(id, key)}']`,
-          ) as HTMLElement;
-
-          if (element) {
-            elements.add(element);
-            element2key.set(element, key);
-            key2element.set(key, element);
-          }
-        });
-
-        return elements;
-      };
-
-      refreshElements();
+      refreshElements(keys, id, elements, key2element, element2key);
 
       // First we should find current focused MenuItem/SubMenu element
       const activeElement = key2element.get(activeKey);
@@ -341,7 +340,7 @@ export default function useAccessibility<T extends HTMLElement>(
         cleanRaf();
         rafRef.current = raf(() => {
           // Async should resync elements
-          refreshElements();
+          refreshElements(keys, id, elements, key2element, element2key);
 
           const controlId = focusMenuElement.getAttribute('aria-controls');
           const subQueryContainer = document.getElementById(controlId);


### PR DESCRIPTION
Fix focus for when the first menu is a group/sub-menu. The issue is with shouldFocusKey calculation, it should skip grouping since it is not focusable.
Related ticket: https://github.com/ant-design/ant-design/issues/45367