### PR TITLE
feat: add `type` to SubMenuType and MenuItemType

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -7,6 +7,8 @@ interface ItemSharedProps {
 }
 
 export interface SubMenuType extends ItemSharedProps {
+  type?: "sub";
+
   label?: React.ReactNode;
 
   children: ItemType[];
@@ -38,6 +40,8 @@ export interface SubMenuType extends ItemSharedProps {
 }
 
 export interface MenuItemType extends ItemSharedProps {
+  type?: 'item';
+
   label?: React.ReactNode;
 
   disabled?: boolean;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -7,7 +7,7 @@ interface ItemSharedProps {
 }
 
 export interface SubMenuType extends ItemSharedProps {
-  type?: "sub";
+  type?: "submenu";
 
   label?: React.ReactNode;
 


### PR DESCRIPTION
ref: [ant-design/ant-design#47260](https://github.com/ant-design/ant-design/issues/47260)

```
items.forEach((item) => {
  console.log(item.type) // "submenu" | "item" | "group" | "divider"
})
```