### PR TITLE
refactor: add extra pass

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -104,7 +104,7 @@
     display: flex;
     align-items: center;
 
-    .@{menuPrefixCls}-extra {
+    .@{menuPrefixCls}-item-extra {
       margin-left: auto;
       font-size: 14px;
     }

--- a/src/MenuItem.tsx
+++ b/src/MenuItem.tsx
@@ -16,7 +16,7 @@ import type { MenuInfo, MenuItemType } from './interface';
 import { warnItemProp } from './utils/warnUtil';
 
 export interface MenuItemProps
-  extends Omit<MenuItemType, 'label' | 'key'| 'ref'>,
+  extends Omit<MenuItemType, 'label' | 'key' | 'ref'>,
     Omit<
       React.HTMLAttributes<HTMLLIElement>,
       'onClick' | 'onMouseEnter' | 'onMouseLeave' | 'onSelect'
@@ -209,7 +209,7 @@ const InternalMenuItem = React.forwardRef(
         role={role === null ? 'none' : role || 'menuitem'}
         tabIndex={disabled ? null : -1}
         data-menu-id={overflowDisabled && domDataId ? null : domDataId}
-        {...restProps}
+        {...omit(restProps, ['extra'])}
         {...activeProps}
         {...optionRoleProps}
         component="li"

--- a/src/utils/nodeUtil.tsx
+++ b/src/utils/nodeUtil.tsx
@@ -49,7 +49,7 @@ function convertItemsToNodes(
         }
 
         return (
-          <MergedMenuItem key={mergedKey} {...restProps}>
+          <MergedMenuItem key={mergedKey} {...restProps} extra={extra}>
             {label}
             {(!!extra || extra === 0) && (
               <span className={`${prefixCls}-item-extra`}>{extra}</span>


### PR DESCRIPTION
https://github.com/ant-design/ant-design/issues/51361

### 背景 
在 5.21.0 中，上了 `extra` 属性，变更 `ant-menu-title-content` 为 `inline-flex`
- 导致这个元素的宽度从原来的 100% 变为子元素决定，引发了样式的 `break`

### 解决方案：
把 `extra` 暴露给 antd，让 antd 感知到，何时使用了 `extra`属性
- 只有使用了该属性，才使用 flex 布局，从而兼容以前的样式

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新菜单组件的样式，改进了菜单项的视觉效果。
	- 在 `MergedMenuItem` 组件中添加了 `extra` 属性，以增强菜单项的功能。

- **样式**
	- 修改了菜单项的样式类名，提高了样式结构的清晰度。
	- 保持了菜单项的活动、选中和禁用状态的样式一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->