### PR TITLE
fix: fix focus when active element is removed

### DIFF
--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -400,10 +400,11 @@ const Menu = React.forwardRef<MenuRef, MenuProps>((props, ref) => {
         const focusableElements = getFocusableElements(containerRef.current, elements);
 
         const shouldFocusKey =
-          mergedActiveKey ??
-          (focusableElements[0]
-            ? element2key.get(focusableElements[0])
-            : childList.find(node => !node.props.disabled)?.key);
+          mergedActiveKey && keys.includes(mergedActiveKey)
+            ? mergedActiveKey
+            : focusableElements[0]
+              ? element2key.get(focusableElements[0])
+              : childList.find(node => !node.props.disabled)?.key;
 
         const elementToFocus = key2element.get(shouldFocusKey);
 


### PR DESCRIPTION
When using the menu with a dropdown that has `autofocus` on, if the menu is closed and the current active item is removed, opening the menu will not focus any item and the arrow keys will not function.

I have attached a video showing this behavior before and after my fix.

### Before
In this video I have created a button and a dropdown with a menu. The button removes the second menu item. I tab to the dropdown, open it, and use the arrow keys to select the second item. Then I press ESC to close the menu. I then tab to the button, press it using ENTER, and then reopen the dropdown by tabbing to it and pressing enter. You will notice that the focus is not in the menu - also I am pressing arrow keys but they do nothing.


https://github.com/user-attachments/assets/cea21afc-01e4-430b-8914-73a89547def9


### After
I perform the same steps as above, but the focus moves to the first item after removing the second item.


https://github.com/user-attachments/assets/3c6171a3-7d32-49f2-9b99-2fd21cc36179




