### PR TITLE
fix: wrong focus behavior when configuring menu selectability

### DIFF
--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -398,15 +398,16 @@ const Menu = React.forwardRef<MenuRef, MenuProps>((props, ref) => {
           ? element2key.get(focusableElements[0])
           : childList.find(node => !node.props.disabled)?.key;
         let shouldFocusKey: string;
-        // find the item to focus on based on whether it is selectable.
+        // find the item to focus on based on whether it is selectable
         if (selectable) {
-          // if there is already a selected item, do not apply the focus.
-          if (!getMergedSelectKeys()?.length) {
-            if (mergedActiveKey && keys.includes(mergedActiveKey)) {
-              shouldFocusKey = mergedActiveKey;
-            } else {
-              shouldFocusKey = defaultFocusKey;
-            }
+          const mergedSelectKeys = getMergedSelectKeys();
+          // if there is already selected items, select first item to focus
+          if (mergedSelectKeys.length && keys.includes(mergedSelectKeys[0])) {
+            shouldFocusKey = mergedSelectKeys[0];
+          } else if (mergedActiveKey && keys.includes(mergedActiveKey)) {
+            shouldFocusKey = mergedActiveKey;
+          } else {
+            shouldFocusKey = defaultFocusKey;
           }
         } else {
           shouldFocusKey = defaultFocusKey;

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -387,6 +387,24 @@ const Menu = React.forwardRef<MenuRef, MenuProps>((props, ref) => {
     setMergedActiveKey(undefined);
   });
 
+  // ======================== Select ========================
+  // >>>>> Select keys
+  const [internalSelectKeys, setMergedSelectKeys] = useControlledState(
+    defaultSelectedKeys || [],
+    selectedKeys,
+  );
+  const mergedSelectKeys = React.useMemo(() => {
+    if (Array.isArray(internalSelectKeys)) {
+      return internalSelectKeys;
+    }
+
+    if (internalSelectKeys === null || internalSelectKeys === undefined) {
+      return EMPTY_LIST;
+    }
+
+    return [internalSelectKeys];
+  }, [internalSelectKeys]);
+  // >>>>> accept ref
   useImperativeHandle(ref, () => {
     return {
       list: containerRef.current,
@@ -400,7 +418,6 @@ const Menu = React.forwardRef<MenuRef, MenuProps>((props, ref) => {
         let shouldFocusKey: string;
         // find the item to focus on based on whether it is selectable
         if (selectable) {
-          const mergedSelectKeys = getMergedSelectKeys();
           // if there is already selected items, select first item to focus
           if (mergedSelectKeys.length && keys.includes(mergedSelectKeys[0])) {
             shouldFocusKey = mergedSelectKeys[0];
@@ -425,27 +442,6 @@ const Menu = React.forwardRef<MenuRef, MenuProps>((props, ref) => {
       },
     };
   });
-
-  // ======================== Select ========================
-  // >>>>> Select keys
-  const [internalSelectKeys, setMergedSelectKeys] = useControlledState(
-    defaultSelectedKeys || [],
-    selectedKeys,
-  );
-  const mergedSelectKeys = React.useMemo(() => {
-    if (Array.isArray(internalSelectKeys)) {
-      return internalSelectKeys;
-    }
-
-    if (internalSelectKeys === null || internalSelectKeys === undefined) {
-      return EMPTY_LIST;
-    }
-
-    return [internalSelectKeys];
-  }, [internalSelectKeys]);
-  function getMergedSelectKeys() {
-    return mergedSelectKeys;
-  }
 
   // >>>>> Trigger select
   const triggerSelection = (info: MenuInfo) => {

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -394,14 +394,22 @@ const Menu = React.forwardRef<MenuRef, MenuProps>((props, ref) => {
         const keys = getKeys();
         const { elements, key2element, element2key } = refreshElements(keys, uuid);
         const focusableElements = getFocusableElements(containerRef.current, elements);
-
+        const defaultFocusKey = focusableElements[0]
+          ? element2key.get(focusableElements[0])
+          : childList.find(node => !node.props.disabled)?.key;
         let shouldFocusKey: string;
-        if (mergedActiveKey && keys.includes(mergedActiveKey)) {
-          shouldFocusKey = mergedActiveKey;
+        // find the item to focus on based on whether it is selectable.
+        if (selectable) {
+          // if there is already a selected item, do not apply the focus.
+          if (!getMergedSelectKeys()?.length) {
+            if (mergedActiveKey && keys.includes(mergedActiveKey)) {
+              shouldFocusKey = mergedActiveKey;
+            } else {
+              shouldFocusKey = defaultFocusKey;
+            }
+          }
         } else {
-          shouldFocusKey = focusableElements[0]
-            ? element2key.get(focusableElements[0])
-            : childList.find(node => !node.props.disabled)?.key;
+          shouldFocusKey = defaultFocusKey;
         }
         const elementToFocus = key2element.get(shouldFocusKey);
 
@@ -434,6 +442,9 @@ const Menu = React.forwardRef<MenuRef, MenuProps>((props, ref) => {
 
     return [internalSelectKeys];
   }, [internalSelectKeys]);
+  function getMergedSelectKeys() {
+    return mergedSelectKeys;
+  }
 
   // >>>>> Trigger select
   const triggerSelection = (info: MenuInfo) => {

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -409,28 +409,26 @@ const Menu = React.forwardRef<MenuRef, MenuProps>((props, ref) => {
     return {
       list: containerRef.current,
       focus: options => {
+        if (!containerRef.current) {
+          return;
+        }
         const keys = getKeys();
         const { elements, key2element, element2key } = refreshElements(keys, uuid);
         const focusableElements = getFocusableElements(containerRef.current, elements);
+        const focusableKeys = new Set(
+          focusableElements.map(el => element2key.get(el)).filter(Boolean),
+        );
         const defaultFocusKey = focusableElements[0]
           ? element2key.get(focusableElements[0])
           : childList.find(node => !node.props.disabled)?.key;
-        let shouldFocusKey: string;
-        // find the item to focus on based on whether it is selectable
-        if (selectable) {
-          // if there is already selected items, select first item to focus
-          if (mergedSelectKeys.length && keys.includes(mergedSelectKeys[0])) {
-            shouldFocusKey = mergedSelectKeys[0];
-          } else if (mergedActiveKey && keys.includes(mergedActiveKey)) {
-            shouldFocusKey = mergedActiveKey;
-          } else {
-            shouldFocusKey = defaultFocusKey;
-          }
-        } else {
-          shouldFocusKey = defaultFocusKey;
-        }
-        const elementToFocus = key2element.get(shouldFocusKey);
+        const selectedFocusKey = mergedSelectKeys.find(k => focusableKeys.has(k));
+        const activeFocusKey =
+          mergedActiveKey && key2element.has(mergedActiveKey) ? mergedActiveKey : undefined;
 
+        const shouldFocusKey = selectable
+          ? (selectedFocusKey ?? activeFocusKey ?? defaultFocusKey)
+          : defaultFocusKey;
+        const elementToFocus = key2element.get(shouldFocusKey);
         if (shouldFocusKey && elementToFocus) {
           elementToFocus?.focus?.(options);
         }

--- a/tests/Focus.spec.tsx
+++ b/tests/Focus.spec.tsx
@@ -1,8 +1,10 @@
 /* eslint-disable no-undef */
 import { act, fireEvent, render } from '@testing-library/react';
 import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import KeyCode from '@rc-component/util/lib/KeyCode';
 import React from 'react';
 import Menu, { MenuItem, MenuItemGroup, MenuRef, SubMenu } from '../src';
+import { isActive } from './util';
 
 describe('Focus', () => {
   beforeAll(() => {
@@ -25,6 +27,24 @@ describe('Focus', () => {
   afterEach(() => {
     jest.useRealTimers();
   });
+
+  function keyDown(container: HTMLElement, keyCode: number) {
+    fireEvent.keyDown(container.querySelector('ul.rc-menu-root'), {
+      which: keyCode,
+      keyCode,
+      charCode: keyCode,
+    });
+
+    // SubMenu raf need slow than accessibility
+    for (let i = 0; i < 20; i += 1) {
+      act(() => {
+        jest.advanceTimersByTime(10);
+      });
+    }
+    act(() => {
+      jest.runAllTimers();
+    });
+  }
 
   it('Get focus', async () => {
     const { container } = await act(async () =>
@@ -185,6 +205,99 @@ describe('Focus', () => {
 
     expect(document.activeElement).toBe(getByTitle('Submenu'));
     expect(getByTestId('sub-menu')).toHaveClass('rc-menu-submenu-active');
+  });
+
+  it('When selectable is not configured, the focus should move to the first available item instead of keeping the previously focused item', async () => {
+    const menuRef = React.createRef<MenuRef>();
+    const items = [
+      { key: '0', label: 'First Item' },
+      { key: '1', label: 'Second Item' },
+      { key: '2', label: 'Third Item' },
+    ];
+    const TestApp = () => {
+      return (
+        <div>
+          <Menu data-testid="menu" selectable={false} ref={menuRef}>
+            {items.map(item => (
+              <MenuItem key={item.key} data-testid={item.key}>
+                {item.label}
+              </MenuItem>
+            ))}
+          </Menu>
+        </div>
+      );
+    };
+    const { getByTestId, container } = render(<TestApp />);
+    // ================ check keydown ==============
+    // first item
+    keyDown(container, KeyCode.DOWN);
+    isActive(container, 0);
+    // second item
+    keyDown(container, KeyCode.DOWN);
+    isActive(container, 1);
+    // select second item
+    keyDown(container, KeyCode.ENTER);
+
+    // mock focus on item 0 to make sure it gets focused
+    const item0 = getByTestId('0');
+    const focusSpy = jest.spyOn(item0, 'focus').mockImplementation(() => {});
+    menuRef.current.focus();
+    expect(focusSpy).toHaveBeenCalled();
+
+    // ================ check click ==============
+    // click third item
+    const item2 = getByTestId('2');
+    fireEvent.click(item2);
+    menuRef.current.focus();
+    expect(focusSpy).toHaveBeenCalled();
+    // cleanup
+    focusSpy.mockRestore();
+  });
+  it('When selectable is configured, the focus should move to the selected item if there is a selection, else to the first item, not retain on last focused item', async () => {
+    const menuRef = React.createRef<MenuRef>();
+    const items = [
+      { key: '0', label: 'First Item' },
+      { key: '1', label: 'Second Item' },
+      { key: '2', label: 'Third Item' },
+    ];
+    const TestApp = () => {
+      return (
+        <div>
+          <Menu data-testid="menu" selectable ref={menuRef}>
+            {items.map(item => (
+              <MenuItem key={item.key} data-testid={item.key}>
+                {item.label}
+              </MenuItem>
+            ))}
+          </Menu>
+        </div>
+      );
+    };
+    const { getByTestId, container } = render(<TestApp />);
+    // ================ check keydown ==============
+    // first item
+    keyDown(container, KeyCode.DOWN);
+    isActive(container, 0);
+    // second item
+    keyDown(container, KeyCode.DOWN);
+    isActive(container, 1);
+    // select second item
+    keyDown(container, KeyCode.ENTER);
+    // mock focus on item 1 to make sure it gets focused
+    const item1 = getByTestId('1');
+    const focusSpy = jest.spyOn(item1, 'focus').mockImplementation(() => {});
+    menuRef.current.focus();
+    expect(focusSpy).toHaveBeenCalled();
+
+    // ================ check click ==============
+    // click third item
+    const item2 = getByTestId('2');
+    fireEvent.click(item2);
+    menuRef.current.focus();
+    // mock focus on item 2 to make sure it gets focused
+    expect(focusSpy).toHaveBeenCalled();
+    // cleanup
+    focusSpy.mockRestore();
   });
 });
 /* eslint-enable */

--- a/tests/Focus.spec.tsx
+++ b/tests/Focus.spec.tsx
@@ -228,7 +228,6 @@ describe('Focus', () => {
       );
     };
     const { getByTestId, container } = render(<TestApp />);
-    // let focusSpy = jest;
     let focusSpy: jest.SpyInstance | undefined;
     try {
       // ================ check keydown ==============
@@ -254,7 +253,7 @@ describe('Focus', () => {
       menuRef.current.focus();
       expect(focusSpy).toHaveBeenCalled();
     } finally {
-      focusSpy.mockRestore();
+      focusSpy?.mockRestore();
     }
   });
   it('When selectable is configured, the focus should move to the selected item if there is a selection, else to the first item, not retain on last focused item', async () => {
@@ -308,6 +307,28 @@ describe('Focus', () => {
       focusSpy?.mockRestore();
       focusSpy2?.mockRestore();
     }
+  });
+  it('should fallback when selected item is disabled', () => {
+    const menuRef = React.createRef<MenuRef>();
+    const items = [
+      { key: '1', label: 'Disabled', disabled: true },
+      { key: '2', label: 'Active' },
+      { key: '3', label: 'Item 3' },
+    ];
+    const { getByTestId } = render(
+      <Menu ref={menuRef} selectable selectedKeys={['disabled']}>
+        {items.map(item => (
+          <MenuItem disabled={item.disabled} key={item.key} data-testid={item.key}>
+            {item.label}
+          </MenuItem>
+        ))}
+      </Menu>,
+    );
+    const item2 = getByTestId('2');
+    const focusSpy = jest.spyOn(item2, 'focus').mockImplementation(() => {});
+    menuRef.current.focus();
+    expect(focusSpy).toHaveBeenCalled();
+    focusSpy?.mockRestore();
   });
 });
 /* eslint-enable */

--- a/tests/Focus.spec.tsx
+++ b/tests/Focus.spec.tsx
@@ -228,30 +228,34 @@ describe('Focus', () => {
       );
     };
     const { getByTestId, container } = render(<TestApp />);
-    // ================ check keydown ==============
-    // first item
-    keyDown(container, KeyCode.DOWN);
-    isActive(container, 0);
-    // second item
-    keyDown(container, KeyCode.DOWN);
-    isActive(container, 1);
-    // select second item
-    keyDown(container, KeyCode.ENTER);
+    // let focusSpy = jest;
+    let focusSpy: jest.SpyInstance | undefined;
+    try {
+      // ================ check keydown ==============
+      // first item
+      keyDown(container, KeyCode.DOWN);
+      isActive(container, 0);
+      // second item
+      keyDown(container, KeyCode.DOWN);
+      isActive(container, 1);
+      // select second item
+      keyDown(container, KeyCode.ENTER);
 
-    // mock focus on item 0 to make sure it gets focused
-    const item0 = getByTestId('0');
-    const focusSpy = jest.spyOn(item0, 'focus').mockImplementation(() => {});
-    menuRef.current.focus();
-    expect(focusSpy).toHaveBeenCalled();
+      // mock focus on item 0 to make sure it gets focused
+      const item0 = getByTestId('0');
+      focusSpy = jest.spyOn(item0, 'focus').mockImplementation(() => {});
+      menuRef.current.focus();
+      expect(focusSpy).toHaveBeenCalled();
 
-    // ================ check click ==============
-    // click third item
-    const item2 = getByTestId('2');
-    fireEvent.click(item2);
-    menuRef.current.focus();
-    expect(focusSpy).toHaveBeenCalled();
-    // cleanup
-    focusSpy.mockRestore();
+      // ================ check click ==============
+      // click third item
+      const item2 = getByTestId('2');
+      fireEvent.click(item2);
+      menuRef.current.focus();
+      expect(focusSpy).toHaveBeenCalled();
+    } finally {
+      focusSpy.mockRestore();
+    }
   });
   it('When selectable is configured, the focus should move to the selected item if there is a selection, else to the first item, not retain on last focused item', async () => {
     const menuRef = React.createRef<MenuRef>();
@@ -274,32 +278,36 @@ describe('Focus', () => {
       );
     };
     const { getByTestId, container } = render(<TestApp />);
-    // ================ check keydown ==============
-    // first item
-    keyDown(container, KeyCode.DOWN);
-    isActive(container, 0);
-    // second item
-    keyDown(container, KeyCode.DOWN);
-    isActive(container, 1);
-    // select second item
-    keyDown(container, KeyCode.ENTER);
-    // mock focus on item 1 to make sure it gets focused
-    const item1 = getByTestId('1');
-    const focusSpy = jest.spyOn(item1, 'focus').mockImplementation(() => {});
-    menuRef.current.focus();
-    expect(focusSpy).toHaveBeenCalled();
+    let focusSpy: jest.SpyInstance | undefined;
+    let focusSpy2: jest.SpyInstance | undefined;
+    try {
+      // ================ check keydown ==============
+      // first item
+      keyDown(container, KeyCode.DOWN);
+      isActive(container, 0);
+      // second item
+      keyDown(container, KeyCode.DOWN);
+      isActive(container, 1);
+      // select second item
+      keyDown(container, KeyCode.ENTER);
+      // mock focus on item 1 to make sure it gets focused
+      const item1 = getByTestId('1');
+      focusSpy = jest.spyOn(item1, 'focus').mockImplementation(() => {});
+      menuRef.current.focus();
+      expect(focusSpy).toHaveBeenCalled();
 
-    // ================ check click ==============
-    // click third item
-    const item2 = getByTestId('2');
-    const focusSpy2 = jest.spyOn(item2, 'focus').mockImplementation(() => {});
-    fireEvent.click(item2);
-    menuRef.current.focus();
-    // mock focus on item 2 to make sure it gets focused
-    expect(focusSpy2).toHaveBeenCalled();
-    // cleanup
-    focusSpy.mockRestore();
-    focusSpy2.mockRestore();
+      // ================ check click ==============
+      // click third item
+      const item2 = getByTestId('2');
+      focusSpy2 = jest.spyOn(item2, 'focus').mockImplementation(() => {});
+      fireEvent.click(item2);
+      menuRef.current.focus();
+      // mock focus on item 2 to make sure it gets focused
+      expect(focusSpy2).toHaveBeenCalled();
+    } finally {
+      focusSpy?.mockRestore();
+      focusSpy2?.mockRestore();
+    }
   });
 });
 /* eslint-enable */

--- a/tests/Focus.spec.tsx
+++ b/tests/Focus.spec.tsx
@@ -292,12 +292,14 @@ describe('Focus', () => {
     // ================ check click ==============
     // click third item
     const item2 = getByTestId('2');
+    const focusSpy2 = jest.spyOn(item2, 'focus').mockImplementation(() => {});
     fireEvent.click(item2);
     menuRef.current.focus();
     // mock focus on item 2 to make sure it gets focused
-    expect(focusSpy).toHaveBeenCalled();
+    expect(focusSpy2).toHaveBeenCalled();
     // cleanup
     focusSpy.mockRestore();
+    focusSpy2.mockRestore();
   });
 });
 /* eslint-enable */


### PR DESCRIPTION
This PR fixes issue https://github.com/ant-design/ant-design/issues/53495

Determine the focus key based on the selectable configuration:

If the item is not selectable, focus the default item.

If the item is selectable, decide whether to focus based on whether there is already a selected item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化菜单组件焦点选择与聚焦行为：当支持可选项时优先聚焦已选项（若存在且有效），否则回退到活跃项或计算的默认焦点；当不支持可选项时始终使用计算的默认焦点，简化并统一聚焦优先级与回退逻辑。

* **Tests**
  * 新增针对可选/不可选场景的焦点交互测试，覆盖键盘导航与点击、聚焦顺序与 focus 调用验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->