### PR TITLE
refactor: 调整 MenuItem 渲染逻辑，将 label 包装在 span 中并优化条件判断

### DIFF
--- a/src/utils/nodeUtil.tsx
+++ b/src/utils/nodeUtil.tsx
@@ -47,13 +47,11 @@ function convertItemsToNodes(
         if (type === 'divider') {
           return <MergedDivider key={mergedKey} {...restProps} />;
         }
-
+        const hasExtra = !!extra || extra === 0;
         return (
           <MergedMenuItem key={mergedKey} {...restProps} extra={extra}>
-            {label}
-            {(!!extra || extra === 0) && (
-              <span className={`${prefixCls}-item-extra`}>{extra}</span>
-            )}
+            {hasExtra ? <span className={`${prefixCls}-item-label`}>{label}</span> : label}
+            {hasExtra && <span className={`${prefixCls}-item-extra`}>{extra}</span>}
           </MergedMenuItem>
         );
       }

--- a/tests/__snapshots__/MenuItem.spec.tsx.snap
+++ b/tests/__snapshots__/MenuItem.spec.tsx.snap
@@ -22,7 +22,11 @@ exports[`MenuItem overwrite default role should set extra to group option 1`] = 
       role="menuitem"
       tabindex="-1"
     >
-      Menu Item 1
+      <span
+        class="rc-menu-item-label"
+      >
+        Menu Item 1
+      </span>
       <span
         class="rc-menu-item-extra"
       >
@@ -40,7 +44,11 @@ exports[`MenuItem overwrite default role should set extra to option 1`] = `
   role="menuitem"
   tabindex="-1"
 >
-  Top Menu Item
+  <span
+    class="rc-menu-item-label"
+  >
+    Top Menu Item
+  </span>
   <span
     class="rc-menu-item-extra"
   >


### PR DESCRIPTION
解决52602 的问题，在 menu 组件中，如果传入了 extra，文字超长时无法显示省略号，因此进行了判断，如果发现有 extra，添加 span 标签包裹。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes（错误修复）**
  * 改进了菜单项中额外内容的渲染逻辑，确保包含额外信息的菜单项能够正确显示和布局。

* **UI/样式改进**
  * 优化了菜单项标签和额外内容的条件渲染，提升了菜单组件的视觉表现。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->