### PR TITLE
fix: add popupRender to SubMenuType

### DIFF
--- a/src/SubMenu/index.tsx
+++ b/src/SubMenu/index.tsx
@@ -38,7 +38,6 @@ export interface SubMenuProps extends Omit<SubMenuType, 'key' | 'children' | 'la
 
   /** @private Do not use. Private warning empty usage */
   warnKey?: boolean;
-  popupRender?: PopupRender;
   // >>>>>>>>>>>>>>>>>>>>> Next  Round <<<<<<<<<<<<<<<<<<<<<<<
   // onDestroy?: DestroyEventHandler;
 }

--- a/src/SubMenu/index.tsx
+++ b/src/SubMenu/index.tsx
@@ -4,7 +4,7 @@ import Overflow from '@rc-component/overflow';
 import warning from '@rc-component/util/lib/warning';
 import SubMenuList from './SubMenuList';
 import { parseChildren } from '../utils/commonUtil';
-import type { MenuInfo, SubMenuType, PopupRender } from '../interface';
+import type { MenuInfo, SubMenuType } from '../interface';
 import MenuContextProvider, { MenuContext } from '../context/MenuContext';
 import useMemoCallback from '../hooks/useMemoCallback';
 import PopupTrigger from './PopupTrigger';

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -33,6 +33,7 @@ export interface SubMenuType extends ItemSharedProps {
   popupClassName?: string;
   popupOffset?: number[];
   popupStyle?: React.CSSProperties;
+  popupRender?: PopupRender;
 
   // >>>>> Events
   onClick?: MenuClickEventHandler;

--- a/tests/Responsive.spec.tsx
+++ b/tests/Responsive.spec.tsx
@@ -15,7 +15,7 @@ jest.mock('@rc-component/resize-observer', () => {
 
   let guid = 0;
 
-  return R.forwardRef((props, ref) => {
+  const MockResizeObserver = R.forwardRef((props, ref) => {
     const [id] = R.useState(() => {
       guid += 1;
       return guid;
@@ -26,6 +26,9 @@ jest.mock('@rc-component/resize-observer', () => {
 
     return R.createElement(RO, { ref, ...props });
   });
+
+  MockResizeObserver.useResizeObserver = RO.useResizeObserver || (() => {});
+  return MockResizeObserver;
 });
 
 describe('Menu.Responsive', () => {


### PR DESCRIPTION
本次修改补充 `SubMenuType` 的 `popupRender` 类型定义，修复 TS 类型检查报错问题。

fix https://github.com/ant-design/ant-design/issues/56706

### 变更内容

- 在 `SubMenuType` 中补充 `popupRender?: PopupRender` 的类型定义

### 影响范围

- 仅类型定义变更，不影响运行时逻辑


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持通过全局/上下文配置为子菜单自定义弹出框渲染，便于统一定制弹出表现。
* **重构**
  * 移除单个子菜单组件上的 per-instance popupRender 属性（不再支持通过组件属性逐个定制），请改用上下文/全局配置以实现自定义渲染。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->