### PR TITLE
fix: wrap item label when extra exists

### DIFF
--- a/src/utils/nodeUtil.tsx
+++ b/src/utils/nodeUtil.tsx
@@ -48,11 +48,17 @@ function convertItemsToNodes(
           return <MergedDivider key={mergedKey} {...restProps} />;
         }
 
+        const hasExtra = !!extra || extra === 0;
+
         return (
           <MergedMenuItem key={mergedKey} {...restProps} extra={extra}>
-            {label}
-            {(!!extra || extra === 0) && (
-              <span className={`${prefixCls}-item-extra`}>{extra}</span>
+            {hasExtra ? (
+              <>
+                <span className={`${prefixCls}-item-label`}>{label}</span>
+                <span className={`${prefixCls}-item-extra`}>{extra}</span>
+              </>
+            ) : (
+              label
             )}
           </MergedMenuItem>
         );

--- a/tests/__snapshots__/MenuItem.spec.tsx.snap
+++ b/tests/__snapshots__/MenuItem.spec.tsx.snap
@@ -22,7 +22,11 @@ exports[`MenuItem overwrite default role should set extra to group option 1`] = 
       role="menuitem"
       tabindex="-1"
     >
-      Menu Item 1
+      <span
+        class="rc-menu-item-label"
+      >
+        Menu Item 1
+      </span>
       <span
         class="rc-menu-item-extra"
       >
@@ -40,7 +44,11 @@ exports[`MenuItem overwrite default role should set extra to option 1`] = `
   role="menuitem"
   tabindex="-1"
 >
-  Top Menu Item
+  <span
+    class="rc-menu-item-label"
+  >
+    Top Menu Item
+  </span>
   <span
     class="rc-menu-item-extra"
   >


### PR DESCRIPTION
## Summary

- Wrap menu item labels with `*-item-label` when `extra` exists
- Keep `*-item-extra` as a sibling of the label for item layout styling
- Update snapshots for item extra rendering

## Test

- npm test -- tests/MenuItem.spec.tsx tests/Options.spec.tsx

Related to ant-design/ant-design#57822

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 修复菜单项额外内容的显示逻辑，确保数值为 0 的额外内容也能正确呈现。
  * 优化菜单项标签和额外内容的渲染结构，提升显示效果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->