### PR TITLE
feat: add itemData to onSelect and onClick callback 

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,13 +135,13 @@ ReactDOM.render(
         </tr>
         <tr>
             <td>onSelect</td>
-            <td>function({key:String, item:ReactComponent, domEvent:Event, selectedKeys:String[], info:{item:MenuItemInfo}})</td>
+            <td>function({key:String, item:ReactComponent, domEvent:Event, selectedKeys:String[],ItemData:ItemData})</td>
             <th></th>
             <td>called when select a menu item</td>
         </tr>
         <tr>
             <td>onClick</td>
-            <td>function({key:String, item:ReactComponent, domEvent:Event, keyPath: String[], info:{item:MenuItemInfo}})</td>
+            <td>function({key:String, item:ReactComponent, domEvent:Event, keyPath: String[], ItemData:ItemData})</td>
             <th></th>
             <td>called when click a menu item</td>
         </tr>

--- a/README.md
+++ b/README.md
@@ -135,13 +135,13 @@ ReactDOM.render(
         </tr>
         <tr>
             <td>onSelect</td>
-            <td>function({key:String, item:ReactComponent, domEvent:Event, selectedKeys:String[]})</td>
+            <td>function({key:String, item:ReactComponent, domEvent:Event, selectedKeys:String[], info:{item:MenuItemType}})</td>
             <th></th>
             <td>called when select a menu item</td>
         </tr>
         <tr>
             <td>onClick</td>
-            <td>function({key:String, item:ReactComponent, domEvent:Event, keyPath: String[]})</td>
+            <td>function({key:String, item:ReactComponent, domEvent:Event, keyPath: String[], info:{item:MenuItemType}})</td>
             <th></th>
             <td>called when click a menu item</td>
         </tr>

--- a/README.md
+++ b/README.md
@@ -135,13 +135,13 @@ ReactDOM.render(
         </tr>
         <tr>
             <td>onSelect</td>
-            <td>function({key:String, item:ReactComponent, domEvent:Event, selectedKeys:String[], info:{item:MenuItemType}})</td>
+            <td>function({key:String, item:ReactComponent, domEvent:Event, selectedKeys:String[], info:{item:MenuItemInfo}})</td>
             <th></th>
             <td>called when select a menu item</td>
         </tr>
         <tr>
             <td>onClick</td>
-            <td>function({key:String, item:ReactComponent, domEvent:Event, keyPath: String[], info:{item:MenuItemType}})</td>
+            <td>function({key:String, item:ReactComponent, domEvent:Event, keyPath: String[], info:{item:MenuItemInfo}})</td>
             <th></th>
             <td>called when click a menu item</td>
         </tr>

--- a/src/MenuItem.tsx
+++ b/src/MenuItem.tsx
@@ -12,7 +12,7 @@ import PrivateContext from './context/PrivateContext';
 import useActive from './hooks/useActive';
 import useDirectionStyle from './hooks/useDirectionStyle';
 import Icon from './Icon';
-import type { MenuInfo, MenuItemType } from './interface';
+import type { MenuInfo, MenuItemInfo, MenuItemType } from './interface';
 import { warnItemProp } from './utils/warnUtil';
 
 export interface MenuItemProps
@@ -34,7 +34,7 @@ export interface MenuItemProps
   attribute?: Record<string, string>;
 
   /** @private Origin item config from items prop */
-  info?: { item: MenuItemType };
+  info?: { item: MenuItemInfo };
 }
 
 // Since Menu event provide the `info.item` which point to the MenuItem node instance.
@@ -138,7 +138,7 @@ const InternalMenuItem = React.forwardRef((props: MenuItemProps, ref: React.Ref<
     e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
   ): MenuInfo => {
     // If propsInfo exists (items mode), use it; otherwise build from props (children mode)
-    const infoItem: MenuItemType = propsInfo?.item || {
+    const infoItem: MenuItemInfo = propsInfo?.item || {
       key: eventKey || '',
       label: children,
       disabled,

--- a/src/MenuItem.tsx
+++ b/src/MenuItem.tsx
@@ -141,7 +141,6 @@ const InternalMenuItem = React.forwardRef((props: MenuItemProps, ref: React.Ref<
     const infoItem: MenuItemInfo = propsInfo?.item || {
       key: eventKey || '',
       label: children,
-      disabled,
       itemIcon,
       extra: props.extra,
     };

--- a/src/MenuItem.tsx
+++ b/src/MenuItem.tsx
@@ -12,7 +12,7 @@ import PrivateContext from './context/PrivateContext';
 import useActive from './hooks/useActive';
 import useDirectionStyle from './hooks/useDirectionStyle';
 import Icon from './Icon';
-import type { MenuInfo, MenuItemInfo, MenuItemType } from './interface';
+import type { MenuInfo, ItemData, MenuItemType } from './interface';
 import { warnItemProp } from './utils/warnUtil';
 
 export interface MenuItemProps
@@ -34,7 +34,7 @@ export interface MenuItemProps
   attribute?: Record<string, string>;
 
   /** @private Origin item config from items prop */
-  info?: { item: MenuItemInfo };
+  itemData?: ItemData;
 }
 
 // Since Menu event provide the `info.item` which point to the MenuItem node instance.
@@ -80,7 +80,7 @@ const InternalMenuItem = React.forwardRef((props: MenuItemProps, ref: React.Ref<
     disabled,
     itemIcon,
     children,
-    info: propsInfo,
+    itemData: propsItemData,
 
     // Aria
     role,
@@ -138,7 +138,7 @@ const InternalMenuItem = React.forwardRef((props: MenuItemProps, ref: React.Ref<
     e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
   ): MenuInfo => {
     // If propsInfo exists (items mode), use it; otherwise build from props (children mode)
-    const infoItem: MenuItemInfo = propsInfo?.item || {
+    const itemData: ItemData = propsItemData || {
       key: eventKey || '',
       label: children,
       itemIcon,
@@ -151,7 +151,7 @@ const InternalMenuItem = React.forwardRef((props: MenuItemProps, ref: React.Ref<
       keyPath: [...connectedKeys].reverse(),
       item: legacyMenuItemRef.current,
       domEvent: e,
-      info: propsInfo || { item: infoItem },
+      itemData: propsItemData || itemData,
     };
   };
 

--- a/src/MenuItem.tsx
+++ b/src/MenuItem.tsx
@@ -32,6 +32,9 @@ export interface MenuItemProps
 
   /** @deprecated No place to use this. Should remove */
   attribute?: Record<string, string>;
+
+  /** @private Origin item config from items prop */
+  info?: { item: MenuItemType };
 }
 
 // Since Menu event provide the `info.item` which point to the MenuItem node instance.
@@ -77,6 +80,7 @@ const InternalMenuItem = React.forwardRef((props: MenuItemProps, ref: React.Ref<
     disabled,
     itemIcon,
     children,
+    info: propsInfo,
 
     // Aria
     role,
@@ -133,12 +137,22 @@ const InternalMenuItem = React.forwardRef((props: MenuItemProps, ref: React.Ref<
   const getEventInfo = (
     e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
   ): MenuInfo => {
+    // If propsInfo exists (items mode), use it; otherwise build from props (children mode)
+    const infoItem: MenuItemType = propsInfo?.item || {
+      key: eventKey || '',
+      label: children,
+      disabled,
+      itemIcon,
+      extra: props.extra,
+    };
+
     return {
       key: eventKey,
       // Note: For legacy code is reversed which not like other antd component
       keyPath: [...connectedKeys].reverse(),
       item: legacyMenuItemRef.current,
       domEvent: e,
+      info: propsInfo || { item: infoItem },
     };
   };
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -99,6 +99,7 @@ export interface MenuInfo {
   /** @deprecated This will not support in future. You should avoid to use this */
   item: React.ReactInstance;
   domEvent: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>;
+  info: { item: MenuItemType };
 }
 
 export interface MenuTitleInfo {

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -64,10 +64,12 @@ export interface MenuItemType extends ItemSharedProps {
 }
 
 /** Info item type passed to onSelect/onClick callbacks, excluding event handlers */
-export type MenuItemInfo = Omit<
-  MenuItemType,
-  'onMouseEnter' | 'onMouseLeave' | 'onClick' | 'className' | 'style' | 'ref'
->;
+export type MenuItemInfo = {
+  label?: React.ReactNode;
+  itemIcon?: RenderIconType;
+  extra?: React.ReactNode;
+  key: React.Key;
+};
 
 export interface MenuItemGroupType extends ItemSharedProps {
   type: 'group';

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -64,7 +64,7 @@ export interface MenuItemType extends ItemSharedProps {
 }
 
 /** Info item type passed to onSelect/onClick callbacks, excluding event handlers */
-export type MenuItemInfo = {
+export type ItemData = {
   label?: React.ReactNode;
   itemIcon?: RenderIconType;
   extra?: React.ReactNode;
@@ -107,7 +107,7 @@ export interface MenuInfo {
   /** @deprecated This will not support in future. You should avoid to use this */
   item: React.ReactInstance;
   domEvent: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>;
-  info: { item: MenuItemInfo };
+  itemData: ItemData;
 }
 
 export interface MenuTitleInfo {

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -63,6 +63,12 @@ export interface MenuItemType extends ItemSharedProps {
   onClick?: MenuClickEventHandler;
 }
 
+/** Info item type passed to onSelect/onClick callbacks, excluding event handlers */
+export type MenuItemInfo = Omit<
+  MenuItemType,
+  'onMouseEnter' | 'onMouseLeave' | 'onClick' | 'className' | 'style' | 'ref'
+>;
+
 export interface MenuItemGroupType extends ItemSharedProps {
   type: 'group';
 
@@ -99,7 +105,7 @@ export interface MenuInfo {
   /** @deprecated This will not support in future. You should avoid to use this */
   item: React.ReactInstance;
   domEvent: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>;
-  info: { item: MenuItemType };
+  info: { item: MenuItemInfo };
 }
 
 export interface MenuTitleInfo {

--- a/src/utils/nodeUtil.tsx
+++ b/src/utils/nodeUtil.tsx
@@ -5,6 +5,7 @@ import MenuItem from '../MenuItem';
 import MenuItemGroup from '../MenuItemGroup';
 import SubMenu from '../SubMenu';
 import { parseChildren } from './commonUtil';
+import { omit } from '@rc-component/util';
 
 function convertItemsToNodes(
   list: ItemType[],
@@ -51,7 +52,12 @@ function convertItemsToNodes(
         const hasExtra = !!extra || extra === 0;
 
         return (
-          <MergedMenuItem key={mergedKey} {...restProps} extra={extra} info={{ item: opt }}>
+          <MergedMenuItem
+            key={mergedKey}
+            {...restProps}
+            extra={extra}
+            info={{ item: omit(opt, ['className', 'style']) }}
+          >
             {hasExtra ? (
               <>
                 <span className={`${prefixCls}-item-label`}>{label}</span>

--- a/src/utils/nodeUtil.tsx
+++ b/src/utils/nodeUtil.tsx
@@ -5,7 +5,7 @@ import MenuItem from '../MenuItem';
 import MenuItemGroup from '../MenuItemGroup';
 import SubMenu from '../SubMenu';
 import { parseChildren } from './commonUtil';
-import { omit } from '@rc-component/util';
+import omit from '@rc-component/util/lib/omit';
 
 function convertItemsToNodes(
   list: ItemType[],

--- a/src/utils/nodeUtil.tsx
+++ b/src/utils/nodeUtil.tsx
@@ -51,7 +51,7 @@ function convertItemsToNodes(
         const hasExtra = !!extra || extra === 0;
 
         return (
-          <MergedMenuItem key={mergedKey} {...restProps} extra={extra}>
+          <MergedMenuItem key={mergedKey} {...restProps} extra={extra} info={{ item: opt }}>
             {hasExtra ? (
               <>
                 <span className={`${prefixCls}-item-label`}>{label}</span>

--- a/src/utils/nodeUtil.tsx
+++ b/src/utils/nodeUtil.tsx
@@ -55,7 +55,7 @@ function convertItemsToNodes(
             key={mergedKey}
             {...restProps}
             extra={extra}
-            info={{ item: { label, key: mergedKey, itemIcon: restProps?.itemIcon, extra } }}
+            itemData={{ label, key: mergedKey, itemIcon: restProps?.itemIcon, extra }}
           >
             {hasExtra ? (
               <>

--- a/src/utils/nodeUtil.tsx
+++ b/src/utils/nodeUtil.tsx
@@ -5,7 +5,6 @@ import MenuItem from '../MenuItem';
 import MenuItemGroup from '../MenuItemGroup';
 import SubMenu from '../SubMenu';
 import { parseChildren } from './commonUtil';
-import omit from '@rc-component/util/lib/omit';
 
 function convertItemsToNodes(
   list: ItemType[],
@@ -56,7 +55,7 @@ function convertItemsToNodes(
             key={mergedKey}
             {...restProps}
             extra={extra}
-            info={{ item: omit(opt, ['className', 'style']) }}
+            info={{ item: { label, key, itemIcon: restProps?.itemIcon, extra } }}
           >
             {hasExtra ? (
               <>

--- a/src/utils/nodeUtil.tsx
+++ b/src/utils/nodeUtil.tsx
@@ -55,7 +55,7 @@ function convertItemsToNodes(
             key={mergedKey}
             {...restProps}
             extra={extra}
-            info={{ item: { label, key, itemIcon: restProps?.itemIcon, extra } }}
+            info={{ item: { label, key: mergedKey, itemIcon: restProps?.itemIcon, extra } }}
           >
             {hasExtra ? (
               <>

--- a/tests/MenuItem.spec.tsx
+++ b/tests/MenuItem.spec.tsx
@@ -181,7 +181,7 @@ describe('MenuItem', () => {
       );
     });
 
-    it('should pass itemData in onSelect and onClick with items', () => {
+    it('should only pass defined itemData properties in onSelect and onClick', () => {
       const onSelect = jest.fn();
       const onClick = jest.fn();
       const { container } = render(
@@ -189,7 +189,7 @@ describe('MenuItem', () => {
           onSelect={onSelect}
           onClick={onClick}
           selectable
-          items={[{ key: '1', label: 'Menu Item' }]}
+          items={[{ key: '1', label: 'Menu Item', foo: '123' }] as any}
         />,
       );
 
@@ -203,12 +203,28 @@ describe('MenuItem', () => {
           }),
         }),
       );
+      expect(onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: '1',
+          itemData: expect.not.objectContaining({
+            foo: '123',
+          }),
+        }),
+      );
       expect(onClick).toHaveBeenCalledWith(
         expect.objectContaining({
           key: '1',
           itemData: expect.objectContaining({
             key: '1',
             label: 'Menu Item',
+          }),
+        }),
+      );
+      expect(onClick).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: '1',
+          itemData: expect.not.objectContaining({
+            foo: '123',
           }),
         }),
       );

--- a/tests/MenuItem.spec.tsx
+++ b/tests/MenuItem.spec.tsx
@@ -150,8 +150,8 @@ describe('MenuItem', () => {
     });
   });
 
-  describe('info.item in event', () => {
-    it('should pass info.item in onSelect and onClick with children', () => {
+  describe('itemData in event', () => {
+    it('should pass itemData in onSelect and onClick with children', () => {
       const onSelect = jest.fn();
       const onClick = jest.fn();
       const { container } = render(
@@ -164,28 +164,24 @@ describe('MenuItem', () => {
       expect(onSelect).toHaveBeenCalledWith(
         expect.objectContaining({
           key: '1',
-          info: expect.objectContaining({
-            item: expect.objectContaining({
-              key: '1',
-              label: 'Menu Item',
-            }),
+          itemData: expect.objectContaining({
+            key: '1',
+            label: 'Menu Item',
           }),
         }),
       );
       expect(onClick).toHaveBeenCalledWith(
         expect.objectContaining({
           key: '1',
-          info: expect.objectContaining({
-            item: expect.objectContaining({
-              key: '1',
-              label: 'Menu Item',
-            }),
+          itemData: expect.objectContaining({
+            key: '1',
+            label: 'Menu Item',
           }),
         }),
       );
     });
 
-    it('should pass info.item in onSelect and onClick with items', () => {
+    it('should pass itemData in onSelect and onClick with items', () => {
       const onSelect = jest.fn();
       const onClick = jest.fn();
       const { container } = render(
@@ -201,22 +197,18 @@ describe('MenuItem', () => {
       expect(onSelect).toHaveBeenCalledWith(
         expect.objectContaining({
           key: '1',
-          info: expect.objectContaining({
-            item: expect.objectContaining({
-              key: '1',
-              label: 'Menu Item',
-            }),
+          itemData: expect.objectContaining({
+            key: '1',
+            label: 'Menu Item',
           }),
         }),
       );
       expect(onClick).toHaveBeenCalledWith(
         expect.objectContaining({
           key: '1',
-          info: expect.objectContaining({
-            item: expect.objectContaining({
-              key: '1',
-              label: 'Menu Item',
-            }),
+          itemData: expect.objectContaining({
+            key: '1',
+            label: 'Menu Item',
           }),
         }),
       );

--- a/tests/MenuItem.spec.tsx
+++ b/tests/MenuItem.spec.tsx
@@ -150,6 +150,79 @@ describe('MenuItem', () => {
     });
   });
 
+  describe('info.item in event', () => {
+    it('should pass info.item in onSelect and onClick with children', () => {
+      const onSelect = jest.fn();
+      const onClick = jest.fn();
+      const { container } = render(
+        <Menu onSelect={onSelect} onClick={onClick} selectable>
+          <MenuItem key="1">Menu Item</MenuItem>
+        </Menu>,
+      );
+
+      fireEvent.click(container.querySelector('.rc-menu-item')!);
+      expect(onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: '1',
+          info: expect.objectContaining({
+            item: expect.objectContaining({
+              key: '1',
+              label: 'Menu Item',
+            }),
+          }),
+        }),
+      );
+      expect(onClick).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: '1',
+          info: expect.objectContaining({
+            item: expect.objectContaining({
+              key: '1',
+              label: 'Menu Item',
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('should pass info.item in onSelect and onClick with items', () => {
+      const onSelect = jest.fn();
+      const onClick = jest.fn();
+      const { container } = render(
+        <Menu
+          onSelect={onSelect}
+          onClick={onClick}
+          selectable
+          items={[{ key: '1', label: 'Menu Item' }]}
+        />,
+      );
+
+      fireEvent.click(container.querySelector('.rc-menu-item')!);
+      expect(onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: '1',
+          info: expect.objectContaining({
+            item: expect.objectContaining({
+              key: '1',
+              label: 'Menu Item',
+            }),
+          }),
+        }),
+      );
+      expect(onClick).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: '1',
+          info: expect.objectContaining({
+            item: expect.objectContaining({
+              key: '1',
+              label: 'Menu Item',
+            }),
+          }),
+        }),
+      );
+    });
+  });
+
   describe('overwrite default role', () => {
     it('should set role to none if null', () => {
       const { container } = render(


### PR DESCRIPTION
## Issue                                                                                                                        

  [Menu 导航菜单 希望在 onSelect，onClick 里获取传入的 item 的 label](https://github.com/ant-design/ant-design/issues/36338)

  ## 背景

  用户在使用 Menu 组件时，希望在 `onSelect` 和 `onClick` 回调中获取菜单项的配置信息（如 label、icon、disabled、extra              
  等）。目前只能获取到 `key`，无法获取其他配置属性。
                                                                                                                                  
  ## 改动                   
                                  
  在 `MenuInfo` 接口中添加 ` itemData: MenuItemType ` 属性，用户可以通过 `info.itemData` 获取菜单项的完整配置。

  ### 改动文件

  - `src/interface.ts` - 添加 `info` 类型定义
  - `src/MenuItem.tsx` - 实现 info.item 的传递（支持 items 配置和 children 两种模式）
  - `src/utils/nodeUtil.tsx` - items 模式传递 itemData prop
  - `tests/MenuItem.spec.tsx` - 添加单元测试                                                                                      
  - `README.md` - 更新文档
                                                                                                                                  
  ## 使用示例               
                                  
  ```tsx                                 
  // items 模式
  <Menu
    items={[{ key: '1', label: '菜单1', icon: <Icon /> }]}
    onClick={(info) => {
      console.log(info.itemData.label); // "菜单1"
      console.log(info.itemData.icon);  // 图标
    }}
  />

  // children 模式
  <Menu>
    <MenuItem key="1" icon={<Icon />}>菜单1</MenuItem>
  </Menu>                                                                                                                         
  onClick={(info) => {
    console.log(info.itemData.label); // "菜单1"                                                                                 
  }}                                                                                                                              
                                  
  Test plan                                                                                                                       
                            
  - 添加单元测试验证 onSelect 和 onClick 中 itemData 的正确性
  - 测试 items 模式和 children 模式      
  - 编译和现有测试全部通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 菜单的 onSelect/onClick 回调在事件参数中新增结构化的菜单项元数据 itemData，项来源（子节点或 items 配置）均可获取。

* **文档**
  * 更新菜单属性说明，补充回调中新增 itemData 参数的结构与示例。

* **测试**
  * 增加测试，验证 itemData 在 onSelect/onClick 中被正确传递与使用。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/menu/pull/864)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->