### PR TITLE
Avoid rc package deep imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,11 +47,11 @@
     "@rc-component/motion": "^1.1.4",
     "@rc-component/overflow": "^1.0.0",
     "@rc-component/trigger": "^3.0.0",
-    "@rc-component/util": "^1.3.0",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.2",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.3",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^16.0.0",

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -1,10 +1,7 @@
 import { clsx } from 'clsx';
 import type { CSSMotionProps } from '@rc-component/motion';
 import Overflow from '@rc-component/overflow';
-import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
-import useId from '@rc-component/util/lib/hooks/useId';
-import isEqual from '@rc-component/util/lib/isEqual';
-import warning from '@rc-component/util/lib/warning';
+import { isEqual, useControlledState, useId, warning } from '@rc-component/util';
 import * as React from 'react';
 import { useImperativeHandle } from 'react';
 import { flushSync } from 'react-dom';

--- a/src/MenuItem.tsx
+++ b/src/MenuItem.tsx
@@ -1,9 +1,6 @@
 import { clsx } from 'clsx';
 import Overflow from '@rc-component/overflow';
-import KeyCode from '@rc-component/util/lib/KeyCode';
-import omit from '@rc-component/util/lib/omit';
-import { useComposeRef } from '@rc-component/util/lib/ref';
-import warning from '@rc-component/util/lib/warning';
+import { KeyCode, omit, useComposeRef, warning } from '@rc-component/util';
 import * as React from 'react';
 import { useMenuId } from './context/IdContext';
 import { MenuContext } from './context/MenuContext';

--- a/src/MenuItemGroup.tsx
+++ b/src/MenuItemGroup.tsx
@@ -1,5 +1,5 @@
 import { clsx } from 'clsx';
-import omit from '@rc-component/util/lib/omit';
+import { omit } from '@rc-component/util';
 import * as React from 'react';
 import { MenuContext } from './context/MenuContext';
 import { useFullPath, useMeasure } from './context/PathContext';

--- a/src/SubMenu/PopupTrigger.tsx
+++ b/src/SubMenu/PopupTrigger.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Trigger from '@rc-component/trigger';
 import { clsx } from 'clsx';
-import raf from '@rc-component/util/lib/raf';
+import { raf } from '@rc-component/util';
 import type { CSSMotionProps } from '@rc-component/motion';
 import { MenuContext } from '../context/MenuContext';
 import { placements, placementsRtl } from '../placements';

--- a/src/SubMenu/index.tsx
+++ b/src/SubMenu/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { clsx } from 'clsx';
 import Overflow from '@rc-component/overflow';
-import warning from '@rc-component/util/lib/warning';
+import { warning } from '@rc-component/util';
 import SubMenuList from './SubMenuList';
 import { parseChildren } from '../utils/commonUtil';
 import type { MenuInfo, SubMenuType } from '../interface';

--- a/src/context/MenuContext.tsx
+++ b/src/context/MenuContext.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import type { CSSMotionProps } from '@rc-component/motion';
-import useMemo from '@rc-component/util/lib/hooks/useMemo';
-import isEqual from '@rc-component/util/lib/isEqual';
+import { isEqual, useMemo } from '@rc-component/util';
 import type {
   BuiltinPlacements,
   MenuClickEventHandler,

--- a/src/hooks/useAccessibility.ts
+++ b/src/hooks/useAccessibility.ts
@@ -1,6 +1,4 @@
-import { getFocusNodeList } from '@rc-component/util/lib/Dom/focus';
-import KeyCode from '@rc-component/util/lib/KeyCode';
-import raf from '@rc-component/util/lib/raf';
+import { getFocusNodeList, KeyCode, raf } from '@rc-component/util';
 import * as React from 'react';
 import { getMenuId } from '../context/IdContext';
 import type { MenuMode } from '../interface';

--- a/src/hooks/useKeyRecords.ts
+++ b/src/hooks/useKeyRecords.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useRef, useCallback } from 'react';
-import warning from '@rc-component/util/lib/warning';
+import { warning } from '@rc-component/util';
 import { nextSlice } from '../utils/timeUtil';
 
 const PATH_SPLIT = '__RC_UTIL_PATH_SPLIT__';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,13 @@ import type { MenuProps } from './Menu';
 import type { MenuItemProps } from './MenuItem';
 import type { SubMenuProps } from './SubMenu';
 import type { MenuItemGroupProps } from './MenuItemGroup';
-import type { MenuRef } from './interface';
+import type {
+  MenuDividerType,
+  MenuItemGroupType,
+  MenuItemType,
+  MenuRef,
+  SubMenuType,
+} from './interface';
 
 export {
   SubMenu,
@@ -26,7 +32,11 @@ export type {
   SubMenuProps,
   MenuItemProps,
   MenuItemGroupProps,
+  MenuDividerType,
+  MenuItemGroupType,
+  MenuItemType,
   MenuRef,
+  SubMenuType,
 };
 
 type MenuType = typeof Menu & {

--- a/src/utils/commonUtil.ts
+++ b/src/utils/commonUtil.ts
@@ -1,4 +1,4 @@
-import toArray from '@rc-component/util/lib/Children/toArray';
+import { toArray } from '@rc-component/util';
 import * as React from 'react';
 
 export function parseChildren(children: React.ReactNode | undefined, keyPath: string[]) {

--- a/src/utils/warnUtil.ts
+++ b/src/utils/warnUtil.ts
@@ -1,4 +1,4 @@
-import warning from '@rc-component/util/lib/warning';
+import { warning } from '@rc-component/util';
 
 /**
  * `onClick` event return `info.item` which point to react node directly.

--- a/tests/Focus.spec.tsx
+++ b/tests/Focus.spec.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 import { act, fireEvent, render } from '@testing-library/react';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import { spyElementPrototypes } from '@rc-component/util';
 import React from 'react';
 import Menu, { MenuItem, MenuItemGroup, MenuRef, SubMenu } from '../src';
 

--- a/tests/Keyboard.spec.tsx
+++ b/tests/Keyboard.spec.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-undef, react/no-multi-comp, react/jsx-curly-brace-presence, max-classes-per-file */
 import { fireEvent, render } from '@testing-library/react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import { KeyCode, spyElementPrototypes } from '@rc-component/util';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import Menu, { MenuItem, SubMenu } from '../src';

--- a/tests/Menu.spec.tsx
+++ b/tests/Menu.spec.tsx
@@ -1,14 +1,12 @@
 /* eslint-disable no-undef, react/no-multi-comp, react/jsx-curly-brace-presence, max-classes-per-file */
 import type { MenuMode } from '@/interface';
 import { fireEvent, render } from '@testing-library/react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
-import { resetWarned } from '@rc-component/util/lib/warning';
+import { KeyCode, resetWarned, spyElementPrototypes } from '@rc-component/util';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import type { MenuRef } from '../src';
 import Menu, { Divider, MenuItem, MenuItemGroup, SubMenu } from '../src';
 import { isActive, last } from './util';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
 
 jest.mock('@rc-component/trigger', () => {
   const react = require('react');

--- a/tests/MenuItem.spec.tsx
+++ b/tests/MenuItem.spec.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 import { fireEvent, render } from '@testing-library/react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import React from 'react';
 import Menu, { MenuItem, MenuItemGroup, SubMenu } from '../src';
 

--- a/tests/Responsive.spec.tsx
+++ b/tests/Responsive.spec.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable no-undef, react/no-multi-comp, react/jsx-curly-brace-presence, max-classes-per-file */
 import { act, fireEvent, render } from '@testing-library/react';
 import ResizeObserver from '@rc-component/resize-observer';
-import KeyCode from '@rc-component/util/lib/KeyCode';
-import { spyElementPrototype } from '@rc-component/util/lib/test/domHook';
+import { KeyCode, spyElementPrototype } from '@rc-component/util';
 import React from 'react';
 import Menu, { MenuItem, SubMenu } from '../src';
 import { OVERFLOW_KEY } from '../src/hooks/useKeyRecords';

--- a/tests/SubMenu.spec.tsx
+++ b/tests/SubMenu.spec.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 import { act, fireEvent, render } from '@testing-library/react';
-import { resetWarned } from '@rc-component/util/lib/warning';
+import { resetWarned } from '@rc-component/util';
 import React from 'react';
 import Menu, { MenuItem, SubMenu } from '../src';
 import { isActive, last } from './util';


### PR DESCRIPTION
## 背景

antd 侧限制继续使用 rc 包的 `lib` / `es` 深路径导入，需要将 menu 中对 rc 包内部路径的依赖迁移到包根入口。

## 调整内容

- 升级 `@rc-component/father-plugin`，使用插件统一拦截 rc 包 `lib` / `es` 深路径导入。
- 升级 `@rc-component/util`。
- 将源码中对 `@rc-component/util` 内部路径的引用改为从包根入口导入。
- 将测试中 `KeyCode`、`resetWarned`、`spyElementPrototypes` 等工具改为从 `@rc-component/util` 根入口导入。

## 验证

- 本次按本地核对后的改动提交。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 对外新增/暴露若干菜单相关类型导出，便于类型引用。
* **Chores**
  * 升级运行时依赖 `@rc-component/util` 至较新版本。
  * 升级开发工具依赖版本。
  * 统一并调整多个模块和测试的导入方式以兼容新依赖。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/menu/pull/865?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->