### PR TITLE
fix: update import paths to resolve no-restricted-imports ESLint errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@rc-component/motion": "^1.1.4",
     "@rc-component/overflow": "^1.0.0",
     "@rc-component/trigger": "^3.0.0",
-    "@rc-component/util": "^1.3.0",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -1,12 +1,11 @@
 import { clsx } from 'clsx';
 import type { CSSMotionProps } from '@rc-component/motion';
 import Overflow from '@rc-component/overflow';
-import { useControlledState } from '@rc-component/util';
+import { useControlledState, warning } from '@rc-component/util';
 /* eslint-disable no-restricted-imports */
 import useId from '@rc-component/util/lib/hooks/useId';
+/* eslint-disable no-restricted-imports */
 import isEqual from '@rc-component/util/lib/isEqual';
-
-import { warning } from '@rc-component/util';
 import * as React from 'react';
 import { useImperativeHandle } from 'react';
 import { flushSync } from 'react-dom';

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -2,9 +2,9 @@ import { clsx } from 'clsx';
 import type { CSSMotionProps } from '@rc-component/motion';
 import Overflow from '@rc-component/overflow';
 import { useControlledState, warning } from '@rc-component/util';
-/* eslint-disable no-restricted-imports */
+// eslint-disable-next-line no-restricted-imports
 import useId from '@rc-component/util/lib/hooks/useId';
-/* eslint-disable no-restricted-imports */
+// eslint-disable-next-line no-restricted-imports
 import isEqual from '@rc-component/util/lib/isEqual';
 import * as React from 'react';
 import { useImperativeHandle } from 'react';

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -1,10 +1,12 @@
 import { clsx } from 'clsx';
 import type { CSSMotionProps } from '@rc-component/motion';
 import Overflow from '@rc-component/overflow';
-import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
+import { useControlledState } from '@rc-component/util';
+/* eslint-disable no-restricted-imports */
 import useId from '@rc-component/util/lib/hooks/useId';
 import isEqual from '@rc-component/util/lib/isEqual';
-import warning from '@rc-component/util/lib/warning';
+
+import { warning } from '@rc-component/util';
 import * as React from 'react';
 import { useImperativeHandle } from 'react';
 import { flushSync } from 'react-dom';

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -1,11 +1,7 @@
 import { clsx } from 'clsx';
 import type { CSSMotionProps } from '@rc-component/motion';
 import Overflow from '@rc-component/overflow';
-import { useControlledState, warning } from '@rc-component/util';
-// eslint-disable-next-line no-restricted-imports
-import useId from '@rc-component/util/lib/hooks/useId';
-// eslint-disable-next-line no-restricted-imports
-import isEqual from '@rc-component/util/lib/isEqual';
+import { useControlledState, warning, useId, isEqual } from '@rc-component/util';
 import * as React from 'react';
 import { useImperativeHandle } from 'react';
 import { flushSync } from 'react-dom';

--- a/src/MenuItem.tsx
+++ b/src/MenuItem.tsx
@@ -1,9 +1,11 @@
 import { clsx } from 'clsx';
 import Overflow from '@rc-component/overflow';
+/* eslint-disable no-restricted-imports */
 import KeyCode from '@rc-component/util/lib/KeyCode';
-import omit from '@rc-component/util/lib/omit';
+
+import { omit } from '@rc-component/util';
 import { useComposeRef } from '@rc-component/util/lib/ref';
-import warning from '@rc-component/util/lib/warning';
+import { warning } from '@rc-component/util';
 import * as React from 'react';
 import { useMenuId } from './context/IdContext';
 import { MenuContext } from './context/MenuContext';

--- a/src/MenuItem.tsx
+++ b/src/MenuItem.tsx
@@ -1,8 +1,8 @@
 import { clsx } from 'clsx';
 import Overflow from '@rc-component/overflow';
-/* eslint-disable no-restricted-imports */
+// eslint-disable-next-line no-restricted-imports
 import KeyCode from '@rc-component/util/lib/KeyCode';
-/* eslint-disable no-restricted-imports */
+// eslint-disable-next-line no-restricted-imports
 import { useComposeRef } from '@rc-component/util/lib/ref';
 import { omit, warning } from '@rc-component/util';
 import * as React from 'react';

--- a/src/MenuItem.tsx
+++ b/src/MenuItem.tsx
@@ -1,10 +1,6 @@
 import { clsx } from 'clsx';
 import Overflow from '@rc-component/overflow';
-// eslint-disable-next-line no-restricted-imports
-import KeyCode from '@rc-component/util/lib/KeyCode';
-// eslint-disable-next-line no-restricted-imports
-import { useComposeRef } from '@rc-component/util/lib/ref';
-import { omit, warning } from '@rc-component/util';
+import { omit, warning, KeyCode, useComposeRef } from '@rc-component/util';
 import * as React from 'react';
 import { useMenuId } from './context/IdContext';
 import { MenuContext } from './context/MenuContext';

--- a/src/MenuItem.tsx
+++ b/src/MenuItem.tsx
@@ -2,10 +2,9 @@ import { clsx } from 'clsx';
 import Overflow from '@rc-component/overflow';
 /* eslint-disable no-restricted-imports */
 import KeyCode from '@rc-component/util/lib/KeyCode';
-
-import { omit } from '@rc-component/util';
+/* eslint-disable no-restricted-imports */
 import { useComposeRef } from '@rc-component/util/lib/ref';
-import { warning } from '@rc-component/util';
+import { omit, warning } from '@rc-component/util';
 import * as React from 'react';
 import { useMenuId } from './context/IdContext';
 import { MenuContext } from './context/MenuContext';

--- a/src/MenuItemGroup.tsx
+++ b/src/MenuItemGroup.tsx
@@ -1,5 +1,5 @@
 import { clsx } from 'clsx';
-import omit from '@rc-component/util/lib/omit';
+import { omit } from '@rc-component/util';
 import * as React from 'react';
 import { MenuContext } from './context/MenuContext';
 import { useFullPath, useMeasure } from './context/PathContext';

--- a/src/SubMenu/PopupTrigger.tsx
+++ b/src/SubMenu/PopupTrigger.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import Trigger from '@rc-component/trigger';
 import { clsx } from 'clsx';
+/* eslint-disable no-restricted-imports */
 import raf from '@rc-component/util/lib/raf';
+
 import type { CSSMotionProps } from '@rc-component/motion';
 import { MenuContext } from '../context/MenuContext';
 import { placements, placementsRtl } from '../placements';

--- a/src/SubMenu/PopupTrigger.tsx
+++ b/src/SubMenu/PopupTrigger.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import Trigger from '@rc-component/trigger';
 import { clsx } from 'clsx';
-// eslint-disable-next-line no-restricted-imports
-import raf from '@rc-component/util/lib/raf';
-
+import { raf } from '@rc-component/util';
 import type { CSSMotionProps } from '@rc-component/motion';
 import { MenuContext } from '../context/MenuContext';
 import { placements, placementsRtl } from '../placements';

--- a/src/SubMenu/PopupTrigger.tsx
+++ b/src/SubMenu/PopupTrigger.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Trigger from '@rc-component/trigger';
 import { clsx } from 'clsx';
-/* eslint-disable no-restricted-imports */
+// eslint-disable-next-line no-restricted-imports
 import raf from '@rc-component/util/lib/raf';
 
 import type { CSSMotionProps } from '@rc-component/motion';

--- a/src/SubMenu/index.tsx
+++ b/src/SubMenu/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { clsx } from 'clsx';
 import Overflow from '@rc-component/overflow';
-import warning from '@rc-component/util/lib/warning';
+import { warning } from '@rc-component/util';
 import SubMenuList from './SubMenuList';
 import { parseChildren } from '../utils/commonUtil';
 import type { MenuInfo, SubMenuType } from '../interface';

--- a/src/context/MenuContext.tsx
+++ b/src/context/MenuContext.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import type { CSSMotionProps } from '@rc-component/motion';
+/* eslint-disable no-restricted-imports */
 import useMemo from '@rc-component/util/lib/hooks/useMemo';
 import isEqual from '@rc-component/util/lib/isEqual';
+
 import type {
   BuiltinPlacements,
   MenuClickEventHandler,

--- a/src/context/MenuContext.tsx
+++ b/src/context/MenuContext.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import type { CSSMotionProps } from '@rc-component/motion';
 /* eslint-disable no-restricted-imports */
 import useMemo from '@rc-component/util/lib/hooks/useMemo';
+/* eslint-disable no-restricted-imports */
 import isEqual from '@rc-component/util/lib/isEqual';
 
 import type {

--- a/src/context/MenuContext.tsx
+++ b/src/context/MenuContext.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
 import type { CSSMotionProps } from '@rc-component/motion';
-// eslint-disable-next-line no-restricted-imports
-import useMemo from '@rc-component/util/lib/hooks/useMemo';
-// eslint-disable-next-line no-restricted-imports
-import isEqual from '@rc-component/util/lib/isEqual';
-
+import { useMemo, isEqual } from '@rc-component/util';
 import type {
   BuiltinPlacements,
   MenuClickEventHandler,

--- a/src/context/MenuContext.tsx
+++ b/src/context/MenuContext.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import type { CSSMotionProps } from '@rc-component/motion';
-/* eslint-disable no-restricted-imports */
+// eslint-disable-next-line no-restricted-imports
 import useMemo from '@rc-component/util/lib/hooks/useMemo';
-/* eslint-disable no-restricted-imports */
+// eslint-disable-next-line no-restricted-imports
 import isEqual from '@rc-component/util/lib/isEqual';
 
 import type {

--- a/src/hooks/useAccessibility.ts
+++ b/src/hooks/useAccessibility.ts
@@ -1,10 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
-import { getFocusNodeList } from '@rc-component/util/lib/Dom/focus';
-// eslint-disable-next-line no-restricted-imports
-import KeyCode from '@rc-component/util/lib/KeyCode';
-// eslint-disable-next-line no-restricted-imports
-import raf from '@rc-component/util/lib/raf';
-
+import { KeyCode, getFocusNodeList, raf } from '@rc-component/util';
 import * as React from 'react';
 import { getMenuId } from '../context/IdContext';
 import type { MenuMode } from '../interface';

--- a/src/hooks/useAccessibility.ts
+++ b/src/hooks/useAccessibility.ts
@@ -1,8 +1,8 @@
-/* eslint-disable no-restricted-imports */
+// eslint-disable-next-line no-restricted-imports
 import { getFocusNodeList } from '@rc-component/util/lib/Dom/focus';
-/* eslint-disable no-restricted-imports */
+// eslint-disable-next-line no-restricted-imports
 import KeyCode from '@rc-component/util/lib/KeyCode';
-/* eslint-disable no-restricted-imports */
+// eslint-disable-next-line no-restricted-imports
 import raf from '@rc-component/util/lib/raf';
 
 import * as React from 'react';

--- a/src/hooks/useAccessibility.ts
+++ b/src/hooks/useAccessibility.ts
@@ -1,6 +1,8 @@
+/* eslint-disable no-restricted-imports */
 import { getFocusNodeList } from '@rc-component/util/lib/Dom/focus';
 import KeyCode from '@rc-component/util/lib/KeyCode';
 import raf from '@rc-component/util/lib/raf';
+
 import * as React from 'react';
 import { getMenuId } from '../context/IdContext';
 import type { MenuMode } from '../interface';

--- a/src/hooks/useAccessibility.ts
+++ b/src/hooks/useAccessibility.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-restricted-imports */
 import { getFocusNodeList } from '@rc-component/util/lib/Dom/focus';
+/* eslint-disable no-restricted-imports */
 import KeyCode from '@rc-component/util/lib/KeyCode';
+/* eslint-disable no-restricted-imports */
 import raf from '@rc-component/util/lib/raf';
 
 import * as React from 'react';

--- a/src/hooks/useKeyRecords.ts
+++ b/src/hooks/useKeyRecords.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useRef, useCallback } from 'react';
-import warning from '@rc-component/util/lib/warning';
+import { warning } from '@rc-component/util';
 import { nextSlice } from '../utils/timeUtil';
 
 const PATH_SPLIT = '__RC_UTIL_PATH_SPLIT__';

--- a/src/utils/commonUtil.ts
+++ b/src/utils/commonUtil.ts
@@ -1,4 +1,4 @@
-import toArray from '@rc-component/util/lib/Children/toArray';
+import { toArray } from '@rc-component/util';
 import * as React from 'react';
 
 export function parseChildren(children: React.ReactNode | undefined, keyPath: string[]) {

--- a/src/utils/warnUtil.ts
+++ b/src/utils/warnUtil.ts
@@ -1,4 +1,4 @@
-import warning from '@rc-component/util/lib/warning';
+import { warning } from '@rc-component/util';
 
 /**
  * `onClick` event return `info.item` which point to react node directly.

--- a/tests/Focus.spec.tsx
+++ b/tests/Focus.spec.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 import { act, fireEvent, render } from '@testing-library/react';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import { spyElementPrototypes } from '@rc-component/util';
 import React from 'react';
 import Menu, { MenuItem, MenuItemGroup, MenuRef, SubMenu } from '../src';
 

--- a/tests/Keyboard.spec.tsx
+++ b/tests/Keyboard.spec.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-undef, react/no-multi-comp, react/jsx-curly-brace-presence, max-classes-per-file */
 import { fireEvent, render } from '@testing-library/react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import { KeyCode, spyElementPrototypes } from '@rc-component/util';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import Menu, { MenuItem, SubMenu } from '../src';

--- a/tests/Menu.spec.tsx
+++ b/tests/Menu.spec.tsx
@@ -1,14 +1,12 @@
 /* eslint-disable no-undef, react/no-multi-comp, react/jsx-curly-brace-presence, max-classes-per-file */
 import type { MenuMode } from '@/interface';
 import { fireEvent, render } from '@testing-library/react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
-import { resetWarned } from '@rc-component/util/lib/warning';
+import { KeyCode, resetWarned, spyElementPrototypes } from '@rc-component/util';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import type { MenuRef } from '../src';
 import Menu, { Divider, MenuItem, MenuItemGroup, SubMenu } from '../src';
 import { isActive, last } from './util';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
 
 jest.mock('@rc-component/trigger', () => {
   const react = require('react');

--- a/tests/MenuItem.spec.tsx
+++ b/tests/MenuItem.spec.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 import { fireEvent, render } from '@testing-library/react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import React from 'react';
 import Menu, { MenuItem, MenuItemGroup, SubMenu } from '../src';
 

--- a/tests/Responsive.spec.tsx
+++ b/tests/Responsive.spec.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable no-undef, react/no-multi-comp, react/jsx-curly-brace-presence, max-classes-per-file */
 import { act, fireEvent, render } from '@testing-library/react';
 import ResizeObserver from '@rc-component/resize-observer';
-import KeyCode from '@rc-component/util/lib/KeyCode';
-import { spyElementPrototype } from '@rc-component/util/lib/test/domHook';
+import { KeyCode, spyElementPrototype } from '@rc-component/util';
 import React from 'react';
 import Menu, { MenuItem, SubMenu } from '../src';
 import { OVERFLOW_KEY } from '../src/hooks/useKeyRecords';

--- a/tests/SubMenu.spec.tsx
+++ b/tests/SubMenu.spec.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 import { act, fireEvent, render } from '@testing-library/react';
-import { resetWarned } from '@rc-component/util/lib/warning';
+import { resetWarned } from '@rc-component/util';
 import React from 'react';
 import Menu, { MenuItem, SubMenu } from '../src';
 import { isActive, last } from './util';


### PR DESCRIPTION
## Summary

- Change lib imports to use package root imports where available
- Add eslint-disable comments for internal hooks not exported from root

## Test plan
- [x] Run `npm run compile` locally to verify build passes

关联 pr：https://github.com/react-component/menu/pull/864


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 统一并简化了若干内部模块的导入方式，提升代码一致性与维护性
  * 更新了内部依赖版本以使用更高版本的工具包
  * 未修改任何对外接口、导出或运行时语义，用户端无功能或行为变化

* **Tests**
  * 调整了测试文件的导入以匹配新的内部导入方式，测试逻辑保持不变

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/menu/pull/866?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->