### PR TITLE
feat: pass full opt object to itemData in convertItemsToNodes

### DIFF
--- a/src/MenuItem.tsx
+++ b/src/MenuItem.tsx
@@ -140,6 +140,7 @@ const InternalMenuItem = React.forwardRef((props: MenuItemProps, ref: React.Ref<
       label: children,
       itemIcon,
       extra: props.extra,
+      title: props.title,
     };
 
     return {

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -69,6 +69,7 @@ export type ItemData = {
   itemIcon?: RenderIconType;
   extra?: React.ReactNode;
   key: React.Key;
+  title?: string;
 };
 
 export interface MenuItemGroupType extends ItemSharedProps {

--- a/src/utils/nodeUtil.tsx
+++ b/src/utils/nodeUtil.tsx
@@ -51,7 +51,7 @@ function convertItemsToNodes(
         const hasExtra = !!extra || extra === 0;
 
         return (
-          <MergedMenuItem key={mergedKey} {...restProps} extra={extra} itemData={opt}>
+          <MergedMenuItem key={mergedKey} {...restProps} extra={extra} itemData={{ ...opt, key: mergedKey }}>
             {hasExtra ? (
               <>
                 <span className={`${prefixCls}-item-label`}>{label}</span>

--- a/src/utils/nodeUtil.tsx
+++ b/src/utils/nodeUtil.tsx
@@ -51,12 +51,7 @@ function convertItemsToNodes(
         const hasExtra = !!extra || extra === 0;
 
         return (
-          <MergedMenuItem
-            key={mergedKey}
-            {...restProps}
-            extra={extra}
-            itemData={{ label, key: mergedKey, itemIcon: restProps?.itemIcon, extra }}
-          >
+          <MergedMenuItem key={mergedKey} {...restProps} extra={extra} itemData={opt}>
             {hasExtra ? (
               <>
                 <span className={`${prefixCls}-item-label`}>{label}</span>

--- a/tests/MenuItem.spec.tsx
+++ b/tests/MenuItem.spec.tsx
@@ -181,51 +181,25 @@ describe('MenuItem', () => {
       );
     });
 
-    it('should only pass defined itemData properties in onSelect and onClick', () => {
+    it('should pass all itemData properties in onSelect and onClick when using items prop', () => {
       const onSelect = jest.fn();
       const onClick = jest.fn();
+      const items = [{ key: '1', label: 'Menu Item', foo: '123', title: 'test title' }];
       const { container } = render(
-        <Menu
-          onSelect={onSelect}
-          onClick={onClick}
-          selectable
-          items={[{ key: '1', label: 'Menu Item', foo: '123' }] as any}
-        />,
+        <Menu onSelect={onSelect} onClick={onClick} selectable items={items as any} />,
       );
 
       fireEvent.click(container.querySelector('.rc-menu-item')!);
       expect(onSelect).toHaveBeenCalledWith(
         expect.objectContaining({
           key: '1',
-          itemData: expect.objectContaining({
-            key: '1',
-            label: 'Menu Item',
-          }),
-        }),
-      );
-      expect(onSelect).toHaveBeenCalledWith(
-        expect.objectContaining({
-          key: '1',
-          itemData: expect.not.objectContaining({
-            foo: '123',
-          }),
+          itemData: expect.objectContaining(items[0]),
         }),
       );
       expect(onClick).toHaveBeenCalledWith(
         expect.objectContaining({
           key: '1',
-          itemData: expect.objectContaining({
-            key: '1',
-            label: 'Menu Item',
-          }),
-        }),
-      );
-      expect(onClick).toHaveBeenCalledWith(
-        expect.objectContaining({
-          key: '1',
-          itemData: expect.not.objectContaining({
-            foo: '123',
-          }),
+          itemData: expect.objectContaining(items[0]),
         }),
       );
     });


### PR DESCRIPTION
  描述：

  ## 改动内容

  在 `src/utils/nodeUtil.tsx` 中，将 `itemData` 从手动构造的部分对象改为直接使用完整的 `opt`
  对象。这样用户传入的所有属性（如 `title`、`fildes`、`test` 等）都能在回调的 `itemData` 中获取到。

  ### 具体修改

  - `src/utils/nodeUtil.tsx`: 将 `itemData={{ label, key: mergedKey, itemIcon: restProps?.itemIcon, extra }}` 改为
  `itemData={opt}`
  - `src/interface.ts`: 在 `ItemData` 接口中添加 `title?: string`（TypeScript 支持）
  - `src/MenuItem.tsx`: 将 `title` prop 传递给 `itemData`

  ## 动机

  当使用 `items` 属性生成菜单项时，用户希望在 `onClick` 或 `onSelect` 回调中通过 `info.itemData` 获取自定义属性。之前
  `itemData` 只包含 `label`、`key`、`itemIcon` 和 `extra`，现在所有传入的属性都会被透传。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新特性**
  * 在菜单项的选择与点击事件回调中，回传的项数据现新增可选的 title 字段，便于直接获取标题信息。

* **行为调整**
  * 菜单内部生成与透传的项数据逻辑已调整，回调中将透传原始项的额外属性以保留更多上下文信息。

* **测试**
  * 更新测试以覆盖 items 场景下完整项数据在回调中被透传的验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->