### PR TITLE
fix: support submenu item title

### DIFF
--- a/src/SubMenu/index.tsx
+++ b/src/SubMenu/index.tsx
@@ -23,10 +23,11 @@ import { useMenuId } from '../context/IdContext';
 import PrivateContext from '../context/PrivateContext';
 
 export type SemanticName = 'list' | 'listTitle';
-export interface SubMenuProps extends Omit<SubMenuType, 'key' | 'children' | 'label'> {
+export interface SubMenuProps extends Omit<SubMenuType, 'key' | 'children' | 'label' | 'title'> {
   classNames?: Partial<Record<SemanticName, string>>;
   styles?: Partial<Record<SemanticName, React.CSSProperties>>;
   title?: React.ReactNode;
+  itemTitle?: string;
 
   children?: React.ReactNode;
 
@@ -51,6 +52,7 @@ const InternalSubMenu = React.forwardRef<HTMLLIElement, SubMenuProps>((props, re
     classNames: menuClassNames,
 
     title,
+    itemTitle,
     eventKey,
     warnKey,
 
@@ -252,7 +254,7 @@ const InternalSubMenu = React.forwardRef<HTMLLIElement, SubMenuProps>((props, re
       className={`${subMenuPrefixCls}-title`}
       tabIndex={mergedDisabled ? null : -1}
       ref={elementRef}
-      title={typeof title === 'string' ? title : null}
+      title={itemTitle ?? (typeof title === 'string' ? title : null)}
       data-menu-id={overflowDisabled && domDataId ? null : domDataId}
       aria-expanded={open}
       aria-haspopup

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -12,6 +12,7 @@ export interface SubMenuType extends ItemSharedProps {
   type?: 'submenu';
 
   label?: React.ReactNode;
+  title?: string;
 
   children: ItemType[];
 

--- a/src/utils/nodeUtil.tsx
+++ b/src/utils/nodeUtil.tsx
@@ -36,8 +36,15 @@ function convertItemsToNodes(
           }
 
           // Sub Menu
+          const { title: itemTitle, ...subMenuRestProps } = restProps;
+
           return (
-            <MergedSubMenu key={mergedKey} {...restProps} title={label}>
+            <MergedSubMenu
+              key={mergedKey}
+              {...subMenuRestProps}
+              title={label}
+              itemTitle={typeof itemTitle === 'string' ? itemTitle : undefined}
+            >
               {convertItemsToNodes(children, components, prefixCls)}
             </MergedSubMenu>
           );
@@ -51,7 +58,12 @@ function convertItemsToNodes(
         const hasExtra = !!extra || extra === 0;
 
         return (
-          <MergedMenuItem key={mergedKey} {...restProps} extra={extra} itemData={{ ...opt, key: mergedKey }}>
+          <MergedMenuItem
+            key={mergedKey}
+            {...restProps}
+            extra={extra}
+            itemData={{ ...opt, key: mergedKey }}
+          >
             {hasExtra ? (
               <>
                 <span className={`${prefixCls}-item-label`}>{label}</span>

--- a/tests/Options.spec.tsx
+++ b/tests/Options.spec.tsx
@@ -41,5 +41,30 @@ describe('Options', () => {
 
     expect(container.children).toMatchSnapshot();
   });
+
+  it('uses submenu item title as native title without replacing label', () => {
+    const { container } = render(
+      <Menu
+        items={[
+          {
+            label: 'Users',
+            key: 'sub1',
+            title: 'People',
+            children: [
+              {
+                label: 'User 1',
+                key: 'user1',
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    const titleNode = container.querySelector('.rc-menu-submenu-title');
+
+    expect(titleNode).toHaveTextContent('Users');
+    expect(titleNode).toHaveAttribute('title', 'People');
+  });
 });
 /* eslint-enable */


### PR DESCRIPTION
### What changed
- Preserve `items[].title` for submenu items as `itemTitle` while keeping `label` as rendered submenu content.
- Use `itemTitle` for the submenu title DOM attribute when present.
- Add a regression test for submenu `items` with different `label` and `title`.

### Why
In the items conversion path, submenu items spread rest props and then set `title={label}`. That overwrote a configured `title`, so downstream consumers could not distinguish display label from native title text.

### Related
- ant-design/ant-design#58387

### Validation
- `npm run lint` (0 errors, existing warnings)
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `./node_modules/.bin/prettier --check src/SubMenu/index.tsx src/interface.ts src/utils/nodeUtil.tsx tests/Options.spec.tsx`
- `npm test -- --runInBand`
- `npm run coverage -- --runInBand`
- `npm run compile`
