### PR TITLE
[WIP] refactor: migration class to FC

### DIFF
--- a/docs/wip-pr-placeholder.md
+++ b/docs/wip-pr-placeholder.md
@@ -1,0 +1,7 @@
+This file is a temporary placeholder for creating a Draft WIP PR for the `LegacyMenuItem` function-component migration work.
+
+It exists only so maintainers can associate the PR with `ant-design/ant-design#58404`.
+
+Planned cleanup:
+
+- Remove this file in the first real implementation commit, or before merge.


### PR DESCRIPTION
## Summary

This is a draft WIP PR created only to associate the upcoming `@rc-component/menu`
migration work with [ant-design/ant-design#58404](https://github.com/ant-design/ant-design/issues/58404).

- add a temporary placeholder file at `docs/wip-pr-placeholder.md`
- remove the placeholder file in the first real implementation commit, or before merge
